### PR TITLE
crgLoader.c: remove C++ comments

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -77,9 +77,9 @@
 #ifdef _WIN64
 #    define stat _stat64
 #elif _WIN32
-    // Nothing to do, default stat uses 32 bit on Windows
+    /* Nothing to do, default stat uses 32 bit on Windows */
 #elif __linux__
-    // Nothing to do, Linux automatically switches between 32-bit and 64-bit version of stat depending on the architecture
+    /* Nothing to do, Linux automatically switches between 32-bit and 64-bit version of stat depending on the architecture */
 #endif
 
 /* ====== TYPE DEFINITIONS ====== */


### PR DESCRIPTION
Currently the code is still compiled as C90 code, where C++-style comments are not allowed.
Remove the C++ comments to make the code compile.