### PR TITLE
Add offsets to crg channel info and read them on load

### DIFF
--- a/c-api/baselib/inc/crgBaseLibPrivate.h
+++ b/c-api/baselib/inc/crgBaseLibPrivate.h
@@ -127,6 +127,7 @@ typedef struct
     double  last;        /* last (maximum) value in this channel              [m] */
     double  inc;         /* increment between two values in this channel      [m] */
     double  mean;        /* mean value used for normalizing a channel         [m] */
+    double  offset;      /* offset value for this channel                     [m] */
 } CrgChannelInfoStruct;
 
 typedef struct  /* channel for double precision data */

--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -56,6 +56,10 @@
 #define dOpcodeRefLineEndZ             18
 #define dOpcodeIncludeItem             19
 #define dOpcodeIncludeDone             20
+#define dOpcodeRefLineOffsetX          21
+#define dOpcodeRefLineOffsetY          22
+#define dOpcodeRefLineOffsetZ          23
+#define dOpcodeRefLineOffsetPhi        24
 
 #define dFileSectionNone                0
 #define dFileSectionRoadCrg             1
@@ -431,10 +435,10 @@ static CrgReaderCallbackStruct	sLoaderCallbacksRoad[] =
    { "long_section_v_right",       decodeHdrDouble,    dOpcodeLongSectionVRight     },
    { "long_section_v_left",        decodeHdrDouble,    dOpcodeLongSectionVLeft      },
    { "long_section_v_increment",   decodeHdrDouble,    dOpcodeLongSectionVIncrement },
-   { "reference_line_offset_x",    decodeHdrDouble,    dOpcodeNone                  },
-   { "reference_line_offset_y",    decodeHdrDouble,    dOpcodeNone                  },
-   { "reference_line_offset_z",    decodeHdrDouble,    dOpcodeNone                  },
-   { "reference_line_offset_phi",  decodeHdrDouble,    dOpcodeNone                  },
+   { "reference_line_offset_x",    decodeHdrDouble,    dOpcodeRefLineOffsetX        },
+   { "reference_line_offset_y",    decodeHdrDouble,    dOpcodeRefLineOffsetY        },
+   { "reference_line_offset_z",    decodeHdrDouble,    dOpcodeRefLineOffsetZ        },
+   { "reference_line_offset_phi",  decodeHdrDouble,    dOpcodeRefLineOffsetPhi      },
    { "$" ,                         setSection,         dFileSectionNone             },
    { "",                NULL,                 -1 }
 };
@@ -743,6 +747,18 @@ decodeHdrDouble( CrgDataStruct* crgData, const char* buffer, int opcode )
         case dOpcodeRefLineEndZ:
             crgData->channelRefZ.info.last = value;
             crgData->admin.defMask |= dCrgDataDefZEnd;
+            break;
+        case dOpcodeRefLineOffsetX:
+            crgData->channelX.info.offset = value;
+            break;
+        case dOpcodeRefLineOffsetY:
+            crgData->channelY.info.offset = value;
+            break;
+        case dOpcodeRefLineOffsetZ:
+            crgData->channelRefZ.info.offset = value;
+            break;
+        case dOpcodeRefLineOffsetPhi:
+            crgData->channelPhi.info.offset = value;
             break;
         case dOpcodeNone:
             break;


### PR DESCRIPTION
The refline offsets are an important part of a CRG file and they should be accessible. Reading and storing the offsets also brings the behavior closer to the MATLAB-API behaviour.

Resolves: #11 