### PR TITLE
Switch to C11 for the C API (issue #43)

### DIFF
--- a/c-api/baselib/makefile
+++ b/c-api/baselib/makefile
@@ -34,8 +34,8 @@ INC_DIR = inc
 COMP = gcc
 
 #Compiler options
-# CFLGS = -Wall -ggdb -ansi -I$(INC_DIR)	#all Warnings with debugging
-CFLGS = -Wall -O3 -ansi -I$(INC_DIR)            #all Warnings with level 3 optimizations
+# CFLGS = -Wall -ggdb -std=c11 -I$(INC_DIR) #all Warnings with debugging
+CFLGS = -Wall -O3 -std=c11 -I$(INC_DIR)     #all Warnings with level 3 optimizations
 
 #Compiler call
 CC = $(COMP) $(CFLGS)

--- a/c-api/demo/Curvature/makefile
+++ b/c-api/demo/Curvature/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgCurvature
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/demo/EvalOptions/makefile
+++ b/c-api/demo/EvalOptions/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgEvalOpts
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/demo/EvalXYnUV/makefile
+++ b/c-api/demo/EvalXYnUV/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgEvalxyuv
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/demo/EvalZ/makefile
+++ b/c-api/demo/EvalZ/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgEvalz
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/demo/Reader/makefile
+++ b/c-api/demo/Reader/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgReader
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/demo/Simple/makefile
+++ b/c-api/demo/Simple/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgSimple
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/Dump/makefile
+++ b/c-api/test/Dump/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgDump
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/MemTest/makefile
+++ b/c-api/test/MemTest/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgMemTest
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/MultiCp/makefile
+++ b/c-api/test/MultiCp/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgMultiCp
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/MultiRead/makefile
+++ b/c-api/test/MultiRead/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgMultiRead
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/PerfTest/makefile
+++ b/c-api/test/PerfTest/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgPerfTest
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/Scan/makefile
+++ b/c-api/test/Scan/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgScan
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm

--- a/c-api/test/Verify/makefile
+++ b/c-api/test/Verify/makefile
@@ -33,7 +33,7 @@ BIN_TGT     =../bin/crgVerify
 COMP = gcc
 
 #Compiler options
-CFLGS = -Wall -ggdb -ansi -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
+CFLGS = -Wall -ggdb -std=c11 -I$(LIB_INC_DIR) -I$(INC_DIR)	#all Warnings with debugging
 
 #linker options
 LFLGS = -L$(LIB_DIR) -lOpenCRG -lm


### PR DESCRIPTION
Replace option `-ansi` (which sets the standard version to C90) with option `-std=c11`.