### PR TITLE
Matlab: remove whitespace at eol

### DIFF
--- a/matlab/crg_init.m
+++ b/matlab/crg_init.m
@@ -10,7 +10,7 @@ function [] = crg_init()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -22,7 +22,7 @@ function [] = crg_init()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/crg_intro.m
+++ b/matlab/crg_intro.m
@@ -277,7 +277,7 @@ function [] = crg_intro()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -289,7 +289,7 @@ function [] = crg_intro()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo.m
+++ b/matlab/demo/crg_demo.m
@@ -6,7 +6,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -18,7 +18,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_belgian_block.m
+++ b/matlab/demo/crg_demo_belgian_block.m
@@ -3,7 +3,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_convert2bin.m
+++ b/matlab/demo/crg_demo_convert2bin.m
@@ -3,7 +3,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_convert2txt.m
+++ b/matlab/demo/crg_demo_convert2txt.m
@@ -3,7 +3,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_country_road.m
+++ b/matlab/demo/crg_demo_country_road.m
@@ -3,7 +3,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_refline.m
+++ b/matlab/demo/crg_demo_gen_refline.m
@@ -14,7 +14,7 @@ function [] = crg_demo_gen_refline()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -26,7 +26,7 @@ function [] = crg_demo_gen_refline()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_sl_mue.m
+++ b/matlab/demo/crg_demo_gen_sl_mue.m
@@ -19,7 +19,7 @@ function [ier] = crg_demo_gen_sl_mue(filename)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [ier] = crg_demo_gen_sl_mue(filename)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_sl_road.m
+++ b/matlab/demo/crg_demo_gen_sl_road.m
@@ -19,7 +19,7 @@ function [ier] = crg_demo_gen_sl_road(filename)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [ier] = crg_demo_gen_sl_road(filename)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_sl_surf.m
+++ b/matlab/demo/crg_demo_gen_sl_surf.m
@@ -19,7 +19,7 @@ function [ier] = crg_demo_gen_sl_surf(filename)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [ier] = crg_demo_gen_sl_surf(filename)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_surface.m
+++ b/matlab/demo/crg_demo_gen_surface.m
@@ -23,7 +23,7 @@ function [] = crg_demo_gen_surface()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [] = crg_demo_gen_surface()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_syntheticStraight.m
+++ b/matlab/demo/crg_demo_gen_syntheticStraight.m
@@ -10,7 +10,7 @@ function [] = crg_demo_gen_syntheticStraight()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -22,7 +22,7 @@ function [] = crg_demo_gen_syntheticStraight()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_gen_target.m
+++ b/matlab/demo/crg_demo_gen_target.m
@@ -17,7 +17,7 @@ function [] = crg_demo_gen_target()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [] = crg_demo_gen_target()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/demo/crg_demo_map_transformation.m
+++ b/matlab/demo/crg_demo_map_transformation.m
@@ -9,7 +9,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -21,7 +21,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -31,7 +31,7 @@
 %
 % * UTM (UTM2BLH, BLH2UTM)
 % * GK (GK2BLH, BLH2GK)
-% * .. 
+% * ..
 %
 
 % DEFAULT SETTINGS
@@ -43,7 +43,7 @@ clc;
 % display format
 format long g;
 
-% example position ASAM e.V. 
+% example position ASAM e.V.
 % (Altlaufstraße 40, 85635 Höhenkirchen-Siegertsbrunn)
 org_llh = [	48.02331, 11.71584, 584.0]; % WGS84
 

--- a/matlab/demo/crg_demo_scale_data.m
+++ b/matlab/demo/crg_demo_scale_data.m
@@ -17,7 +17,7 @@ function [data] = crg_demo_scale_data(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_demo_scale_data(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/copy_ax2fig.m
+++ b/matlab/lib/copy_ax2fig.m
@@ -5,7 +5,7 @@ function [] = copy_ax2fig()
 %   subplot of a complex figure.
 %   -   If the subplot is a surface plot, a colorbar is attached to the new
 %       figure.
-%   -   If the subplot has a legend, a legend will be attached to the new 
+%   -   If the subplot has a legend, a legend will be attached to the new
 %       figure.
 %   In order for the function to work, each subplot must be have its
 %   ButtonDownFcn set to COPY_AX2FIG. To set this property for the current
@@ -16,7 +16,7 @@ function [] = copy_ax2fig()
 %       set(axis_handle,'ButtonDownFcn','copy_ax2fig');
 %       set(line_handle,'ButtonDownFcn','copy_ax2fig');
 %   'line_handle' represents either a line handle, a surface handle, or a plot
-%   handle. If there are multiple line objects, all must be set. 
+%   handle. If there are multiple line objects, all must be set.
 %   With both the line object and the axis object set, it does not matter
 %   whether the axis object or the line object is clicked on.
 %
@@ -41,7 +41,7 @@ function [] = copy_ax2fig()
 %
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -53,7 +53,7 @@ function [] = copy_ax2fig()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_append.m
+++ b/matlab/lib/crg_append.m
@@ -28,7 +28,7 @@ function [data, roff2] = crg_append(data1, data2)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -40,7 +40,7 @@ function [data, roff2] = crg_append(data1, data2)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_b2z.m
+++ b/matlab/lib/crg_b2z.m
@@ -1,6 +1,6 @@
 function [data] = crg_b2z(data, b)
 % CRG_B2Z Apply banking to OpenCRG data.
-%   CRG_B2Z(DATA, B) applies new banking to an OpenCRG struct. Existing 
+%   CRG_B2Z(DATA, B) applies new banking to an OpenCRG struct. Existing
 %   banking data is merged into the road data.
 %
 %   Inputs:
@@ -22,7 +22,7 @@ function [data] = crg_b2z(data, b)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [data] = crg_b2z(data, b)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check.m
+++ b/matlab/lib/crg_check.m
@@ -17,7 +17,7 @@ function [data] = crg_check(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_curvature.m
+++ b/matlab/lib/crg_check_curvature.m
@@ -26,7 +26,7 @@ function [data, ierr, idxArr] = crg_check_curvature(data, ierr)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -38,7 +38,7 @@ function [data, ierr, idxArr] = crg_check_curvature(data, ierr)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -82,7 +82,7 @@ ierr = ierr + icerr;
 if isfield(data.opts, 'wcvl') && data.opts.wcvl > 0 && icerr > 0
     % set temp ok
     data.ok = 0;
-    
+
     % reference line points
     uges=data.head.ubeg:data.head.uinc:data.head.uend;
     uinc=data.head.uinc;
@@ -95,7 +95,7 @@ if isfield(data.opts, 'wcvl') && data.opts.wcvl > 0 && icerr > 0
 
     % min max v values from curvature radius
     min_max_v = NaN(size(vek_rc));
-    min_max_v(idx_right)=ceil(1./vek_rc(idx_right)./data.head.uinc).*data.head.uinc; 
+    min_max_v(idx_right)=ceil(1./vek_rc(idx_right)./data.head.uinc).*data.head.uinc;
     min_max_v(idx_left) =floor(1./vek_rc(idx_left)./data.head.uinc).*data.head.uinc;
 
     % max grid cells array
@@ -115,7 +115,7 @@ if isfield(data.opts, 'wcvl') && data.opts.wcvl > 0 && icerr > 0
     zright = crg_eval_uv2z(data,[uges',(rightNaNBorder-uinc)']);
 
     % check if z isnan
-    if sum(isnan(zleft))==size(data.z,1) && sum(isnan(zright))==size(data.z,1) 
+    if sum(isnan(zleft))==size(data.z,1) && sum(isnan(zright))==size(data.z,1)
         warning('local curvature check succeeded - critical curvature areas in NaN regions')
         ierr = ierr - icerr;
     else
@@ -131,7 +131,7 @@ if isfield(data.opts, 'wcvl') && data.opts.wcvl > 0 && icerr > 0
             idxArr = [iRight(1) iRight(end)];
         end
     end
-    
+
     % remove temp ok
     data = rmfield(data, 'ok');
 end

--- a/matlab/lib/crg_check_data.m
+++ b/matlab/lib/crg_check_data.m
@@ -19,7 +19,7 @@ function [data] = crg_check_data(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [data] = crg_check_data(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -136,7 +136,7 @@ if round((uend-ubeg)/uinc)+1 ~= nu
     warning('CRG:checkWarning', 'DATA.u->ubeg/uend/uinc not consistent with number of rows of DATA.z')
     ierr = 1;
 end
-    
+
 data.head.ubeg = ubeg;
 data.head.uend = uend;
 data.head.uinc = uinc;
@@ -233,7 +233,7 @@ if vinc > 0
     else
         data.v = single([vmin vmax]);
     end
-    
+
     if round((vmax-vmin)/vinc)+1 ~= nv
         warning('CRG:checkWarning', 'DATA.v->vmin/vmax/vinc not consistent with number of columns of DATA.z')
         ierr = 1;
@@ -589,7 +589,7 @@ if isfield(data, 'p') && length(data.p)==nu-1 % variable heading (curved refline
 
     % curvature check (global and local)
     [data, ierr] = crg_check_curvature(data, ierr);
-    
+
 else % constant heading (straight refline)
     if ~isfield(data.head, 'xbeg')
         data.head.xbeg = 0;
@@ -762,7 +762,7 @@ function [data] = crg_check_data_rflc(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -774,7 +774,7 @@ function [data] = crg_check_data_rflc(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_head.m
+++ b/matlab/lib/crg_check_head.m
@@ -17,7 +17,7 @@ function [data] = crg_check_head(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_head(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_mods.m
+++ b/matlab/lib/crg_check_mods.m
@@ -17,7 +17,7 @@ function [data] = crg_check_mods(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_mods(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_mpro.m
+++ b/matlab/lib/crg_check_mpro.m
@@ -17,7 +17,7 @@ function [data] = crg_check_mpro(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_mpro(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_opts.m
+++ b/matlab/lib/crg_check_opts.m
@@ -17,7 +17,7 @@ function [data] = crg_check_opts(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_opts(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_single.m
+++ b/matlab/lib/crg_check_single.m
@@ -1,6 +1,6 @@
 function [data] = crg_check_single(data)
 %CRG_CHECK_SINGLE Check core OpenCRG data for type single.
-%   [DATA] = CRG_CHECK_SINGLE(DATA) checks whether OpenCRG data in core data 
+%   [DATA] = CRG_CHECK_SINGLE(DATA) checks whether OpenCRG data in core data
 %   vectors and arrays is of type single.
 %
 %   Inputs:
@@ -17,7 +17,7 @@ function [data] = crg_check_single(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_single(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_uv_descript.m
+++ b/matlab/lib/crg_check_uv_descript.m
@@ -50,7 +50,7 @@ function [v] = crg_check_uv_descript(uv_descript, posmode)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -62,7 +62,7 @@ function [v] = crg_check_uv_descript(uv_descript, posmode)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_check_wgs84.m
+++ b/matlab/lib/crg_check_wgs84.m
@@ -17,7 +17,7 @@ function [data] = crg_check_wgs84(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_check_wgs84(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -57,28 +57,28 @@ if isfield(data, 'mpro')
         data.ok = 0; % add ok flag to prevent checking
         llh = crg_eval_xyz2llh(data, [data.head.xbeg data.head.ybeg data.head.zbeg]);
         data = rmfield(data, 'ok'); % remove ok flag
-        
+
         if ~isfield(data.head, 'ebeg')
             data.head.nbeg = 180/pi*llh(1);
             data.head.ebeg = 180/pi*llh(2);
         end
-        
+
         if ~isfield(data.head, 'abeg')
             data.head.abeg = llh(3);
         end
     end
-    
+
     % add consistent end definitions (we already checked for existing pairs in crg_check_head)
     if ~isfield(data.head, 'eend') || ~isfield(data.head, 'aend') % add missing (eend, nend) pair and/or aend
         data.ok = 0; % add ok flag to prevent checking
         llh = crg_eval_xyz2llh(data, [data.head.xend, data.head.yend, data.head.zend]);
         data = rmfield(data, 'ok'); % remove ok flag
-        
+
         if ~isfield(data.head, 'eend')
         data.head.nend = 180/pi*llh(1);
         data.head.eend = 180/pi*llh(2);
         end
-        
+
         if ~isfield(data.head, 'aend')
             data.head.aend = llh(3);
         end
@@ -88,25 +88,25 @@ if isfield(data, 'mpro')
     data.ok = 0; % add ok flag to prevent checking
     xyz = crg_eval_llh2xyz(data, [pi/180*data.head.nbeg pi/180*data.head.ebeg data.head.abeg]);
     data = rmfield(data, 'ok'); % remove ok flag
-    
+
     if norm(xyz - [data.head.xbeg data.head.ybeg data.head.zbeg]) > crgpro
         warning('CRG:checkWarning', 'inconsistent definition of header data "reference_line_start_x/y/z" and "reference_line_start_lon/lat/alt"')
         ierr = 1;
     end
-    
+
    % check consistent end definitions
     data.ok = 0; % add ok flag to prevent checking
     xyz = crg_eval_llh2xyz(data, [pi/180*data.head.nend pi/180*data.head.eend data.head.aend]);
     data = rmfield(data, 'ok'); % remove ok flag
-    
+
     if norm(xyz - [data.head.xend data.head.yend data.head.zend]) > crgpro
         warning('CRG:checkWarning', 'inconsistent definition of header data "reference_line_end_x/y/z" and "reference_line_end_lon/lat/alt"')
         ierr = 1;
     end
-    
+
 else
     %% check for consistent start-end distance (we already checked for existing start and pairs in crg_check_head)
-    
+
     % local rectangular coordinate system <> WGS84 world geodetic system
     if isfield(data.head, 'xend') && isfield(data.head, 'eend')
         dxy = sqrt((data.head.xend-data.head.xbeg)^2 + (data.head.yend-data.head.ybeg)^2);
@@ -115,7 +115,7 @@ else
             warning('CRG:checkWarning', 'inconsistent distance definition of header data "reference_line_start/end_x/y" and "reference_line_start/end_lon/lat"')
             ierr = 1;
         end
-    end 
+    end
 end
 
 %% check for consistent altitude definitions (we already checked for existing start in crg_check_head)

--- a/matlab/lib/crg_cut_iuiv.m
+++ b/matlab/lib/crg_cut_iuiv.m
@@ -20,7 +20,7 @@ function [data] = crg_cut_iuiv(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [data] = crg_cut_iuiv(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_enh2xyz.m
+++ b/matlab/lib/crg_eval_enh2xyz.m
@@ -20,7 +20,7 @@ function [pxyz, data] = crg_eval_enh2xyz(data, penh)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [pxyz, data] = crg_eval_enh2xyz(data, penh)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_llh2xyz.m
+++ b/matlab/lib/crg_eval_llh2xyz.m
@@ -20,7 +20,7 @@ function [pxyz, data] = crg_eval_llh2xyz(data, pllh)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [pxyz, data] = crg_eval_llh2xyz(data, pllh)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_u2crv.m
+++ b/matlab/lib/crg_eval_u2crv.m
@@ -19,7 +19,7 @@ function [crv, data] = crg_eval_u2crv(data, pu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [crv, data] = crg_eval_u2crv(data, pu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_u2phi.m
+++ b/matlab/lib/crg_eval_u2phi.m
@@ -19,7 +19,7 @@ function [phi, data] = crg_eval_u2phi(data, pu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [phi, data] = crg_eval_u2phi(data, pu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_uv2iuiv.m
+++ b/matlab/lib/crg_eval_uv2iuiv.m
@@ -22,7 +22,7 @@ function [iu, iv] = crg_eval_uv2iuiv(data, u, v)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [iu, iv] = crg_eval_uv2iuiv(data, u, v)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_uv2xy.m
+++ b/matlab/lib/crg_eval_uv2xy.m
@@ -19,7 +19,7 @@ function [pxy, data] = crg_eval_uv2xy(data, puv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [pxy, data] = crg_eval_uv2xy(data, puv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_uv2z.m
+++ b/matlab/lib/crg_eval_uv2z.m
@@ -12,14 +12,14 @@ function [pz, data] = crg_eval_uv2z(data, puv)
 %       DATA    struct array as defined in CRG_INTRO.
 %
 %   Examples:
-%   pz = crg_eval_uv2z(data, puv) 
+%   pz = crg_eval_uv2z(data, puv)
 %       Evaluates the z-values at the given u/v-positions.
 %
 %   See also CRG_INTRO.
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [pz, data] = crg_eval_uv2z(data, puv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_xy2uv.m
+++ b/matlab/lib/crg_eval_xy2uv.m
@@ -20,7 +20,7 @@ function [puv, data] = crg_eval_xy2uv(data, pxy)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [puv, data] = crg_eval_xy2uv(data, pxy)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_xy2z.m
+++ b/matlab/lib/crg_eval_xy2z.m
@@ -20,7 +20,7 @@ function [pz, data] = crg_eval_xy2z(data, pxy)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [pz, data] = crg_eval_xy2z(data, pxy)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_xyz2enh.m
+++ b/matlab/lib/crg_eval_xyz2enh.m
@@ -20,7 +20,7 @@ function [penh, data] = crg_eval_xyz2enh(data, pxyz)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [penh, data] = crg_eval_xyz2enh(data, pxyz)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_eval_xyz2llh.m
+++ b/matlab/lib/crg_eval_xyz2llh.m
@@ -20,7 +20,7 @@ function [pllh, data] = crg_eval_xyz2llh(data, pxyz)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [pllh, data] = crg_eval_xyz2llh(data, pxyz)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_ext_banking.m
+++ b/matlab/lib/crg_ext_banking.m
@@ -18,7 +18,7 @@ function [ data ] = crg_ext_banking( data, pp )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [ data ] = crg_ext_banking( data, pp )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_ext_slope.m
+++ b/matlab/lib/crg_ext_slope.m
@@ -18,7 +18,7 @@ function [ data ] = crg_ext_slope( data, p )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [ data ] = crg_ext_slope( data, p )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_figure.m
+++ b/matlab/lib/crg_figure.m
@@ -15,7 +15,7 @@ function [data] = crg_figure(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -27,7 +27,7 @@ function [data] = crg_figure(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_filter.m
+++ b/matlab/lib/crg_filter.m
@@ -38,7 +38,7 @@ function [data] = crg_filter(data, iu, iv, fm, mask, wopt)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -50,7 +50,7 @@ function [data] = crg_filter(data, iu, iv, fm, mask, wopt)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_flip.m
+++ b/matlab/lib/crg_flip.m
@@ -15,7 +15,7 @@ function [data] = crg_flip(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -27,7 +27,7 @@ function [data] = crg_flip(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_gen_csb2crg0.m
+++ b/matlab/lib/crg_gen_csb2crg0.m
@@ -67,7 +67,7 @@ function [data] = crg_gen_csb2crg0(inc, u, v, c, s, b)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -79,7 +79,7 @@ function [data] = crg_gen_csb2crg0(inc, u, v, c, s, b)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_gen_ppxy2phi.m
+++ b/matlab/lib/crg_gen_ppxy2phi.m
@@ -38,7 +38,7 @@ function [data, err] = crg_gen_ppxy2phi(ppxy, uinc, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -50,7 +50,7 @@ function [data, err] = crg_gen_ppxy2phi(ppxy, uinc, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_gen_pxy2ppxy.m
+++ b/matlab/lib/crg_gen_pxy2ppxy.m
@@ -21,7 +21,7 @@ function [ppxy] = crg_gen_pxy2ppxy(pxy, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [ppxy] = crg_gen_pxy2ppxy(pxy, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_isequal.m
+++ b/matlab/lib/crg_isequal.m
@@ -27,7 +27,7 @@ function [ident, dd] = crg_isequal( bcrg, acrg )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -39,7 +39,7 @@ function [ident, dd] = crg_isequal( bcrg, acrg )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_limiter.m
+++ b/matlab/lib/crg_limiter.m
@@ -24,7 +24,7 @@ function [ data ] = crg_limiter( data, mmlim, iu, iv )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [ data ] = crg_limiter( data, mmlim, iu, iv )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_map_uv2uv.m
+++ b/matlab/lib/crg_map_uv2uv.m
@@ -24,7 +24,7 @@ function [ data ] = crg_map_uv2uv( data, crg_uv, iu, iv )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [ data ] = crg_map_uv2uv( data, crg_uv, iu, iv )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_map_xy2xy.m
+++ b/matlab/lib/crg_map_xy2xy.m
@@ -24,7 +24,7 @@ function [ data ] = crg_map_xy2xy( data, crg_xy, iu, iv )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [ data ] = crg_map_xy2xy( data, crg_xy, iu, iv )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_mods.m
+++ b/matlab/lib/crg_mods.m
@@ -19,7 +19,7 @@ function [data] = crg_mods(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [data] = crg_mods(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -76,7 +76,7 @@ function [data] = crg_mods_scale(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -88,7 +88,7 @@ function [data] = crg_mods_scale(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -261,7 +261,7 @@ function [data] = crg_mods_byoff(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -273,7 +273,7 @@ function [data] = crg_mods_byoff(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -359,16 +359,16 @@ if rlop ~= 0 % rotate by rlop
 
     ps = sin(rlop);
     pc = cos(rlop);
-    
+
     % rotate by rlop around (xbeg, ybeg)
-    
+
     dx = data.head.xend - data.head.xbeg;
     dy = data.head.yend - data.head.ybeg;
     data.head.xend = data.head.xbeg + dx*pc - dy*ps;
     data.head.yend = data.head.ybeg + dx*ps + dy*pc;
-    
-    % add offset resulting from distance (rlrx, rlry)->(xbeg, ybeg) 
-    
+
+    % add offset resulting from distance (rlrx, rlry)->(xbeg, ybeg)
+
     dx = data.head.xbeg - rlrx;
     dy = data.head.ybeg - rlry;
     rlox = rlox + dx*pc - dy*ps - dx;
@@ -441,7 +441,7 @@ function [data] = crg_mods_byref(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -453,7 +453,7 @@ function [data] = crg_mods_byref(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -603,7 +603,7 @@ function [data] = crg_mods_gnan(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -615,7 +615,7 @@ function [data] = crg_mods_gnan(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_peakfinder.m
+++ b/matlab/lib/crg_peakfinder.m
@@ -25,7 +25,7 @@ function [ pindex, pij] = crg_peakfinder( data, iu, iv, th, ra )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -37,7 +37,7 @@ function [ pindex, pij] = crg_peakfinder( data, iu, iv, th, ra )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_perform2surface.m
+++ b/matlab/lib/crg_perform2surface.m
@@ -20,7 +20,7 @@ function [data] = crg_perform2surface(data, uv_surf, oper)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [data] = crg_perform2surface(data, uv_surf, oper)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_elgrid_cross_sect.m
+++ b/matlab/lib/crg_plot_elgrid_cross_sect.m
@@ -23,7 +23,7 @@ function [data] = crg_plot_elgrid_cross_sect(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_plot_elgrid_cross_sect(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_elgrid_limits.m
+++ b/matlab/lib/crg_plot_elgrid_limits.m
@@ -24,7 +24,7 @@ function [data] = crg_plot_elgrid_limits(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_plot_elgrid_limits(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_elgrid_long_sect.m
+++ b/matlab/lib/crg_plot_elgrid_long_sect.m
@@ -23,7 +23,7 @@ function [data] = crg_plot_elgrid_long_sect(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_plot_elgrid_long_sect(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_elgrid_uvz_map.m
+++ b/matlab/lib/crg_plot_elgrid_uvz_map.m
@@ -23,7 +23,7 @@ function [data] = crg_plot_elgrid_uvz_map(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_plot_elgrid_uvz_map(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_elgrid_xyz_map.m
+++ b/matlab/lib/crg_plot_elgrid_xyz_map.m
@@ -23,7 +23,7 @@ function [data] = crg_plot_elgrid_xyz_map(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_plot_elgrid_xyz_map(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_curvature.m
+++ b/matlab/lib/crg_plot_refline_curvature.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_curvature(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_curvature(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_elevation.m
+++ b/matlab/lib/crg_plot_refline_elevation.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_elevation(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_elevation(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_heading.m
+++ b/matlab/lib/crg_plot_refline_heading.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_heading(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_heading(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_slope_bank.m
+++ b/matlab/lib/crg_plot_refline_slope_bank.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_slope_bank(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_slope_bank(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_xy_map_and_curv.m
+++ b/matlab/lib/crg_plot_refline_xy_map_and_curv.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_xy_map_and_curv(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_xy_map_and_curv(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_xy_overview_map.m
+++ b/matlab/lib/crg_plot_refline_xy_overview_map.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_xy_overview_map(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_xy_overview_map(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refline_xyz_map.m
+++ b/matlab/lib/crg_plot_refline_xyz_map.m
@@ -21,7 +21,7 @@ function [data] = crg_plot_refline_xyz_map(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_plot_refline_xyz_map(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_refpnt_distances.m
+++ b/matlab/lib/crg_plot_refpnt_distances.m
@@ -17,7 +17,7 @@ function [data] = crg_plot_refpnt_distances(data, pxy)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_plot_refpnt_distances(data, pxy)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_road_uv2uvz_map.m
+++ b/matlab/lib/crg_plot_road_uv2uvz_map.m
@@ -18,7 +18,7 @@ function [data] = crg_plot_road_uv2uvz_map(data, u, v)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [data] = crg_plot_road_uv2uvz_map(data, u, v)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_road_uv2xyz_map.m
+++ b/matlab/lib/crg_plot_road_uv2xyz_map.m
@@ -18,7 +18,7 @@ function [data] = crg_plot_road_uv2xyz_map(data, u, v)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [data] = crg_plot_road_uv2xyz_map(data, u, v)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_road_uvz_map.m
+++ b/matlab/lib/crg_plot_road_uvz_map.m
@@ -23,7 +23,7 @@ function [data] = crg_plot_road_uvz_map(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_plot_road_uvz_map(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_plot_road_xyz_map.m
+++ b/matlab/lib/crg_plot_road_xyz_map.m
@@ -24,7 +24,7 @@ function [data] = crg_plot_road_xyz_map(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_plot_road_xyz_map(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_read.m
+++ b/matlab/lib/crg_read.m
@@ -15,7 +15,7 @@ function [data] = crg_read(file)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -27,7 +27,7 @@ function [data] = crg_read(file)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -328,17 +328,17 @@ data = crg_check_head(data);
 
 if length(block) > 0
     data.mpro = struct;
-    
+
     data.mpro.gell = struct;
     data.mpro.lell = struct;
     data.mpro.tran = struct;
     data.mpro.proj = struct;
-    
+
     for i = 1:length(block)
         hc = block{i};
         if strncmp(hc, '*', 1), continue, end % skip comment lines
         hc = regexprep(hc, '!+.*', ''); % erase inline comments
-        
+
         % all unknown keywords and many syntax flaws will be silently ignored
         [pname, pvalue] = strread(hc, '%s%s', 1, 'delimiter', '=');
         pvalue = pvalue{1};
@@ -388,7 +388,7 @@ if length(block) > 0
                 data.mpro.proj.n0 = str2double(pvalue);
         end
     end
-    
+
     data = crg_check_mpro(data);
 end
 

--- a/matlab/lib/crg_rerender.m
+++ b/matlab/lib/crg_rerender.m
@@ -24,7 +24,7 @@ function [ data ] = crg_rerender( crg, inc, v )
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [ data ] = crg_rerender( crg, inc, v )
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_s2z.m
+++ b/matlab/lib/crg_s2z.m
@@ -1,6 +1,6 @@
 function [data] = crg_s2z(data, rz)
 % CRG_S2Z Apply slope to OpenCRG data.
-%   CRG_S2Z(DATA, RZ) applies new slope to an OpenCRG struct. Existing 
+%   CRG_S2Z(DATA, RZ) applies new slope to an OpenCRG struct. Existing
 %   slope data is merged into the road data.
 %
 %   Inputs:
@@ -23,7 +23,7 @@ function [data] = crg_s2z(data, rz)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_s2z(data, rz)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_separate_sb.m
+++ b/matlab/lib/crg_separate_sb.m
@@ -31,7 +31,7 @@ function [data] = crg_separate_sb(data, swlen, bwlen)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -43,7 +43,7 @@ function [data] = crg_separate_sb(data, swlen, bwlen)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show.m
+++ b/matlab/lib/crg_show.m
@@ -24,7 +24,7 @@ function [data] = crg_show(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_show(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_elgrid_cuts_and_limits.m
+++ b/matlab/lib/crg_show_elgrid_cuts_and_limits.m
@@ -24,7 +24,7 @@ function [data] = crg_show_elgrid_cuts_and_limits(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_show_elgrid_cuts_and_limits(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_elgrid_surface.m
+++ b/matlab/lib/crg_show_elgrid_surface.m
@@ -23,7 +23,7 @@ function [data] = crg_show_elgrid_surface(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [data] = crg_show_elgrid_surface(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_info.m
+++ b/matlab/lib/crg_show_info.m
@@ -15,7 +15,7 @@ function [data] = crg_show_info(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -27,7 +27,7 @@ function [data] = crg_show_info(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_isequal.m
+++ b/matlab/lib/crg_show_isequal.m
@@ -17,7 +17,7 @@ function [] = crg_show_isequal(dd, out)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [] = crg_show_isequal(dd, out)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_peaks.m
+++ b/matlab/lib/crg_show_peaks.m
@@ -1,7 +1,7 @@
 function [data] = crg_show_peaks(data, pindex, su, sv, iu, iv)
 % CRG_SHOW_PEAKS Visualize peaks.
 %   DATA = CRG_SHOW_PEAKS(DATA, PINDEX, SU, SV, IU, IV) visualizes peaks in
-%   OpenCRG data. Peaks are usually identified via CRG_PEAKFINDER. 
+%   OpenCRG data. Peaks are usually identified via CRG_PEAKFINDER.
 %   The plots and the display of peaks in these plots can be
 %   limited to a selected area of the grid.
 %
@@ -29,7 +29,7 @@ function [data] = crg_show_peaks(data, pindex, su, sv, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -41,7 +41,7 @@ function [data] = crg_show_peaks(data, pindex, su, sv, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_refline_elevation.m
+++ b/matlab/lib/crg_show_refline_elevation.m
@@ -21,7 +21,7 @@ function [data] = crg_show_refline_elevation(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [data] = crg_show_refline_elevation(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_refline_map.m
+++ b/matlab/lib/crg_show_refline_map.m
@@ -20,7 +20,7 @@ function [data] = crg_show_refline_map(data, iu)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [data] = crg_show_refline_map(data, iu)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_refpnts_and_refline.m
+++ b/matlab/lib/crg_show_refpnts_and_refline.m
@@ -17,7 +17,7 @@ function [data] = crg_show_refpnts_and_refline(data, pxy)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_show_refpnts_and_refline(data, pxy)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_road_surface.m
+++ b/matlab/lib/crg_show_road_surface.m
@@ -1,6 +1,6 @@
 function [data] = crg_show_road_surface(data, iu, iv)
 % CRG_SHOW_ELGRID_SURFACE Visualize the road surface.
-%   DATA = CRG_SHOW_ELGRID_SURFACE(DATA, IU, IV) visualizes the road surface 
+%   DATA = CRG_SHOW_ELGRID_SURFACE(DATA, IU, IV) visualizes the road surface
 %   via orthographic images and 3-dimensional surface plots. The plots can be
 %   limited to a selected area of the grid.
 %
@@ -24,7 +24,7 @@ function [data] = crg_show_road_surface(data, iu, iv)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_show_road_surface(data, iu, iv)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_show_road_uv2surface.m
+++ b/matlab/lib/crg_show_road_uv2surface.m
@@ -1,6 +1,6 @@
 function [data] = crg_show_road_uv2surface(data, u, v)
 % CRG_SHOW_ELGRID_UV2SURFACE Visualize the road surface on a given grid.
-%   DATA = CRG_SHOW_ELGRID_UV2SURFACE(DATA, U, V) visualizes the road surface 
+%   DATA = CRG_SHOW_ELGRID_UV2SURFACE(DATA, U, V) visualizes the road surface
 %   via orthographic images and 3-dimensional surface plots on a given grid.
 %
 %   Inputs:
@@ -17,7 +17,7 @@ function [data] = crg_show_road_uv2surface(data, u, v)
 %
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_show_road_uv2surface(data, u, v)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_single.m
+++ b/matlab/lib/crg_single.m
@@ -10,14 +10,14 @@ function [data] = crg_single(data)
 %   DATA    input DATA with road data converted to type single.
 %
 %   Examples:
-%   data = crg_single(data); 
+%   data = crg_single(data);
 %       Converts CRG road data to type single.
 %
 %   See also CRG_INTRO.
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_single(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_surf.m
+++ b/matlab/lib/crg_surf.m
@@ -20,7 +20,7 @@ function [data] = crg_surf(data, x, y, z)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [data] = crg_surf(data, x, y, z)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_crg2html.m
+++ b/matlab/lib/crg_wgs84_crg2html.m
@@ -24,7 +24,7 @@ function [data] = crg_wgs84_crg2html(data, file, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -36,7 +36,7 @@ function [data] = crg_wgs84_crg2html(data, file, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_dist.m
+++ b/matlab/lib/crg_wgs84_dist.m
@@ -29,7 +29,7 @@ function [dist dbeg dend] = crg_wgs84_dist(wgs1, wgs2)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -41,7 +41,7 @@ function [dist dbeg dend] = crg_wgs84_dist(wgs1, wgs2)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_invdist.m
+++ b/matlab/lib/crg_wgs84_invdist.m
@@ -27,7 +27,7 @@ function [wgs2 dend] = crg_wgs84_invdist(wgs1, dbeg, dist)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -39,7 +39,7 @@ function [wgs2 dend] = crg_wgs84_invdist(wgs1, dbeg, dist)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_setend.m
+++ b/matlab/lib/crg_wgs84_setend.m
@@ -22,7 +22,7 @@ function [data] = crg_wgs84_setend(data, dref)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [data] = crg_wgs84_setend(data, dref)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_wgs2url.m
+++ b/matlab/lib/crg_wgs84_wgs2url.m
@@ -23,7 +23,7 @@ function [url] = crg_wgs84_wgs2url(wgs, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -35,7 +35,7 @@ function [url] = crg_wgs84_wgs2url(wgs, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_wgsxy2wgs.m
+++ b/matlab/lib/crg_wgs84_wgsxy2wgs.m
@@ -27,7 +27,7 @@ function [wgs] = crg_wgs84_wgsxy2wgs(wgs1, wgs2, pxy1, pxy2, pxy, eps, tol, dmin
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -39,7 +39,7 @@ function [wgs] = crg_wgs84_wgsxy2wgs(wgs1, wgs2, pxy1, pxy2, pxy, eps, tol, dmin
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_wgs84_xy2wgs.m
+++ b/matlab/lib/crg_wgs84_xy2wgs.m
@@ -21,7 +21,7 @@ function [wgs, data] = crg_wgs84_xy2wgs(data, pxy)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [wgs, data] = crg_wgs84_xy2wgs(data, pxy)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -64,11 +64,11 @@ np = size(pxy, 1);
 if isfield(data, 'mpro') % mapping projection data is available
     xyz = zeros(np, 3);
     xyz(:, 1:2) = pxy;
-    
+
     llh = crg_eval_xyz2llh(data, xyz);
-    
+
     wgs = llh(:, 1:2) * 180/pi;
-    
+
     return
 end
 

--- a/matlab/lib/crg_wrap.m
+++ b/matlab/lib/crg_wrap.m
@@ -17,7 +17,7 @@ function [data] = crg_wrap(data)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ function [data] = crg_wrap(data)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/crg_write.m
+++ b/matlab/lib/crg_write.m
@@ -20,7 +20,7 @@ function [ier] = crg_write(data, file, type)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -32,7 +32,7 @@ function [ier] = crg_write(data, file, type)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -219,15 +219,15 @@ clear c head
 %% generate struct data blocks $MPRO_* with map projection data
 
 if isfield(data, 'mpro') % mapping projection data is available
-    
+
     c = cell(1,0);
-    
+
     %% process GELL (global geodetic datum)
-    
+
     gell = data.mpro.gell;
 
     % generate struct data block lines
-    
+
     switch gell.nm
         case 'WGS84'
             %
@@ -239,15 +239,15 @@ if isfield(data, 'mpro') % mapping projection data is available
         otherwise
             c{end+1} = sprintf('%s = ''%s''' , 'gell_nm', gell.nm);
     end
-    
+
     clear gell
-   
+
     %% process TRAN (datum transformation)
-    
+
     tran = data.mpro.tran;
 
     % generate struct data block lines
-    
+
     switch tran.nm
         case {'HL7','HN7','HS7'}
             c{end+1} = sprintf('%s = ''%s''' , 'tran_nm', tran.nm);
@@ -259,15 +259,15 @@ if isfield(data, 'mpro') % mapping projection data is available
             if tran.ty ~= 0, c{end+1} = sprintf('%s = %24.16e', 'tran_ty', tran.ty); end
             if tran.tz ~= 0, c{end+1} = sprintf('%s = %24.16e', 'tran_tz', tran.tz); end
     end
-    
+
     clear tran
-   
+
     %% process LELL (local geodetic datum)
-    
+
     lell = data.mpro.lell;
 
     % generate struct data block lines
-    
+
     switch lell.nm
         case 'WGS84'
             %
@@ -279,17 +279,17 @@ if isfield(data, 'mpro') % mapping projection data is available
         otherwise
             c{end+1} = sprintf('%s = ''%s''' , 'lell_nm', lell.nm);
     end
-    
+
     clear lell
-   
+
     %% process PROJ (map projection)
-    
+
     proj = data.mpro.proj;
 
     % generate struct data block lines
-    
+
     c{end+1} = sprintf('%s = ''%s''' , 'proj_nm', proj.nm);
-    
+
     if length(proj.nm) < 3
         if proj.l0 ~= 0, c{end+1} = sprintf('%s = %24.16e', 'proj_l0', proj.l0); end
     elseif strcmp(proj.nm(1:3), 'TM_')
@@ -300,13 +300,13 @@ if isfield(data, 'mpro') % mapping projection data is available
     end
 
     clear proj
-    
+
     %% write struct data block
-    
+
     crgdat.struct = sdf_add(crgdat.struct, 'ROAD_CRG_MPRO', c);
-    
+
     clear c
-   
+
 end
 
 %% add further struct data if available

--- a/matlab/lib/ipl_demo.m
+++ b/matlab/lib/ipl_demo.m
@@ -12,7 +12,7 @@ function [] = ipl_demo()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -24,7 +24,7 @@ function [] = ipl_demo()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/ipl_read.m
+++ b/matlab/lib/ipl_read.m
@@ -40,7 +40,7 @@ function [data] = ipl_read(filename, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -52,7 +52,7 @@ function [data] = ipl_read(filename, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/ipl_write.m
+++ b/matlab/lib/ipl_write.m
@@ -29,7 +29,7 @@ function [ier] = ipl_write(data, filename, type)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -41,7 +41,7 @@ function [ier] = ipl_write(data, filename, type)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_check.m
+++ b/matlab/lib/map_check.m
@@ -25,7 +25,7 @@ function [dat] = map_check(dat)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -37,7 +37,7 @@ function [dat] = map_check(dat)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_check_elli.m
+++ b/matlab/lib/map_check_elli.m
@@ -3,7 +3,7 @@ function [ell] = map_check_elli(ell)
 %   [ELL] = MAP_CHECK_ELLI(ELL) checks and updates the ellipsoid struct.
 %
 %   Inputs:
-%   ELL     optional ellipsoid name (default: 'WGS84') or ELLI struct 
+%   ELL     optional ellipsoid name (default: 'WGS84') or ELLI struct
 %
 %   Outputs:
 %   ELL     ELLI struct
@@ -16,7 +16,7 @@ function [ell] = map_check_elli(ell)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -28,7 +28,7 @@ function [ell] = map_check_elli(ell)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -101,7 +101,7 @@ switch nm % EPSG data retrieved 2012-11-01 http://www.epsg-registry.org
         b = a*(1 - 1/298.3);
     case 'WGS84' % EPSG::7030
         a = 6378137;
-        b = a*(1 - 1/298.257223563);       
+        b = a*(1 - 1/298.257223563);
     case 'USERDEFINED'
         if isfield(ell, 'a')
             a = ell.a;

--- a/matlab/lib/map_check_proj.m
+++ b/matlab/lib/map_check_proj.m
@@ -3,7 +3,7 @@ function [pro] = map_check_proj(pro)
 %   [PRO] = MAP_CHECK_PROJ(PRO, LOC) checks and updates map projection struct.
 %%
 %   Inputs:
-%   PRO     projection name or PROJ struct 
+%   PRO     projection name or PROJ struct
 %
 %   Outputs:
 %   PRO     PROJ struct
@@ -16,7 +16,7 @@ function [pro] = map_check_proj(pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -28,7 +28,7 @@ function [pro] = map_check_proj(pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -63,9 +63,9 @@ switch nm
         if ~isreal(z) || isnan(z) || (floor(z)~=z) || (z<0) || (z>119)
             error('MAP:checkError', 'illegal GK3 projection zone number %s', zone)
         end
-        
+
         zone = sprintf('%3.3d', z);
-        
+
         f0 = 1;
         p0 = 0;
         l0 = pi/180 * 3*z;
@@ -79,9 +79,9 @@ switch nm
         if ~isreal(z) || isnan(z) || (floor(z)~=z) || (z<0) || (z>59)
             error('MAP:checkError', 'illegal GK6 projection zone number %s', zone)
         end
-        
+
         zone = sprintf('%2.2d', z);
-        
+
         f0 = 1;
         p0 = 0;
         l0 = pi/180 * (6*z - 3);
@@ -104,9 +104,9 @@ switch nm
         if ~isreal(z) || isnan(z) || (floor(z)~=z) || (z<1) || (z>60)
             error('MAP:checkError', 'illegal UTM grid zone number %s', zone(1:end-1))
         end
-        
+
         zone = sprintf('%2.2d%s', z, zone(end:end));
-        
+
         f0 = 0.9996;
         p0 = 0;
         l0 = pi/180 * (6*z - 183);
@@ -122,15 +122,15 @@ switch nm
         l0 = 0; if isfield(pro, 'l0'), l0 = pro.l0; end
         e0 = 0; if isfield(pro, 'e0'), e0 = pro.e0; end
         n0 = 0; if isfield(pro, 'n0'), n0 = pro.n0; end
-        
+
         if ~isempty(zone)
             z = str2double(zone);
             if ~isreal(z) || isnan(z) || (floor(z)~=z) || (z<0) || (z>359)
                 error('MAP:checkError', 'illegal projection center meridian %s', zone)
             end
-            
+
             zone = sprintf('%3.3d', z);
-            
+
             l0 = pi/180 * z;
         end
     otherwise

--- a/matlab/lib/map_check_tran.m
+++ b/matlab/lib/map_check_tran.m
@@ -16,7 +16,7 @@ function [tran] = map_check_tran(tran)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -28,7 +28,7 @@ function [tran] = map_check_tran(tran)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_ecef2ecef.m
+++ b/matlab/lib/map_ecef2ecef.m
@@ -22,7 +22,7 @@ function [xyzb tran] = map_ecef2ecef(xyza, tran, fwbw)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [xyzb tran] = map_ecef2ecef(xyza, tran, fwbw)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -43,7 +43,7 @@ function [xyzb tran] = map_ecef2ecef(xyza, tran, fwbw)
 %% check and complement inputs
 
 % FWBW
-if nargin < 3 || isempty(fwbw) 
+if nargin < 3 || isempty(fwbw)
     fwbw = 'F';
 end
 fwbw = upper(fwbw);
@@ -94,7 +94,7 @@ switch nm
         s2 = sin(ry);
         c3 = cos(rz);
         s3 = sin(rz);
-    
+
         s = [c2*c3           -c2*s3           s2; ...
             c1*s3+s1*s2*c3 c1*c3-s1*s2*s3 -s1*c2; ...
             s1*s3-c1*s2*c3 s1*c3+c1*s2*s3  c1*c2]';
@@ -113,7 +113,7 @@ switch nm
             -ry             +rx             1+ds]';
         ds = 0;
 end
-        
+
 %% evaluate transformation
 
 n = size(xyza,1);
@@ -139,49 +139,49 @@ end
 % 'Input: - _
 %  cartesian XYZ coords (X,Y,Z), X translation (DX) all in meters ; _
 %  Y and Z rotations in seconds of arc (Y_Rot, Z_Rot) and scale in ppm (s).
-%  
+%
 % 'Convert rotations to radians and ppm scale to a factor
 %     Pi = 3.14159265358979
 %     sfactor = s * 0.000001
 %     RadY_Rot = (Y_Rot / 3600) * (Pi / 180)
 %     RadZ_Rot = (Z_Rot / 3600) * (Pi / 180)
-%     
+%
 % 'Compute transformed X coord
 %     Helmert_X = X + (X * sfactor) - (Y * RadZ_Rot) + (Z * RadY_Rot) + DX
-%  
+%
 % End Function
-% 
+%
 % Function Helmert_Y(X, Y, Z, DY, X_Rot, Z_Rot, s)
 % 'Computed Helmert transformed Y coordinate.
 % 'Input: - _
 %  cartesian XYZ coords (X,Y,Z), Y translation (DY) all in meters ; _
 %  X and Z rotations in seconds of arc (X_Rot, Z_Rot) and scale in ppm (s).
-%  
+%
 % 'Convert rotations to radians and ppm scale to a factor
 %     Pi = 3.14159265358979
 %     sfactor = s * 0.000001
 %     RadX_Rot = (X_Rot / 3600) * (Pi / 180)
 %     RadZ_Rot = (Z_Rot / 3600) * (Pi / 180)
-%     
+%
 % 'Compute transformed Y coord
 %     Helmert_Y = (X * RadZ_Rot) + Y + (Y * sfactor) - (Z * RadX_Rot) + DY
-%  
+%
 % End Function
-% 
+%
 % Function Helmert_Z(X, Y, Z, DZ, X_Rot, Y_Rot, s)
 % 'Computed Helmert transformed Z coordinate.
 % 'Input: - _
 %  cartesian XYZ coords (X,Y,Z), Z translation (DZ) all in meters ; _
 %  X and Y rotations in seconds of arc (X_Rot, Y_Rot) and scale in ppm (s).
-%  
+%
 % 'Convert rotations to radians and ppm scale to a factor
 %     Pi = 3.14159265358979
 %     sfactor = s * 0.000001
 %     RadX_Rot = (X_Rot / 3600) * (Pi / 180)
 %     RadY_Rot = (Y_Rot / 3600) * (Pi / 180)
-%     
+%
 % 'Compute transformed Z coord
 %     Helmert_Z = (-1 * X * RadY_Rot) + (Y * RadX_Rot) + Z + (Z * sfactor) + DZ
-%  
+%
 % End Function
 

--- a/matlab/lib/map_ecef2geod.m
+++ b/matlab/lib/map_ecef2geod.m
@@ -19,7 +19,7 @@ function [llh ell] = map_ecef2geod(xyz, ell)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [llh ell] = map_ecef2geod(xyz, ell)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -82,12 +82,12 @@ while i < m
     sinphi = sin(phi);
     cosphi = cos(phi);
     b1 = atan2((1-f)*sinphi, cosphi);
-    
+
     mabs = max(abs(b1-b0));
     if mabs < 2*beps
         break
     end
-    
+
     i = i + 1;
 end
 if (i == m) && (mabs > 10*beps)
@@ -118,22 +118,22 @@ end
 % 'Convert XYZ to Latitude (PHI) in Dec Degrees.
 % 'Input: - _
 %  XYZ cartesian coords (X,Y,Z) and ellipsoid axis dimensions (a & b), all in meters.
-% 
+%
 % 'THIS FUNCTION REQUIRES THE "Iterate_XYZ_to_Lat" FUNCTION
 % 'THIS FUNCTION IS CALLED BY THE "XYZ_to_H" FUNCTION
-% 
+%
 %     RootXYSqr = Sqr((X ^ 2) + (Y ^ 2))
 %     e2 = ((a ^ 2) - (b ^ 2)) / (a ^ 2)
 %     PHI1 = Atn(Z / (RootXYSqr * (1 - e2)))
-%     
+%
 %     PHI = Iterate_XYZ_to_Lat(a, e2, PHI1, Z, RootXYSqr)
-%     
+%
 %     Pi = 3.14159265358979
-%     
+%
 %     XYZ_to_Lat = PHI * (180 / Pi)
-% 
+%
 % End Function
-% 
+%
 % Function Iterate_XYZ_to_Lat(a, e2, PHI1, Z, RootXYSqr)
 % 'Iteratively computes Latitude (PHI).
 % 'Input: - _
@@ -142,68 +142,68 @@ end
 %  estimated value for latitude (PHI1) in radians; _
 %  cartesian Z coordinate (Z) in meters; _
 %  RootXYSqr computed from X & Y in meters.
-% 
+%
 % 'THIS FUNCTION IS CALLED BY THE "XYZ_to_PHI" FUNCTION
 % 'THIS FUNCTION IS ALSO USED ON IT'S OWN IN THE _
 %  "Projection and Transformation Calculations.xls" SPREADSHEET
-% 
-% 
+%
+%
 %     V = a / (Sqr(1 - (e2 * ((Sin(PHI1)) ^ 2))))
 %     PHI2 = Atn((Z + (e2 * V * (Sin(PHI1)))) / RootXYSqr)
-%     
+%
 %     Do While Abs(PHI1 - PHI2) > 0.000000001
 %         PHI1 = PHI2
 %         V = a / (Sqr(1 - (e2 * ((Sin(PHI1)) ^ 2))))
 %         PHI2 = Atn((Z + (e2 * V * (Sin(PHI1)))) / RootXYSqr)
 %     Loop
-% 
+%
 %     Iterate_XYZ_to_Lat = PHI2
-% 
+%
 % End Function
-% 
+%
 % Function XYZ_to_Long(X, Y)
 % 'Convert XYZ to Longitude (LAM) in Dec Degrees.
 % 'Input: - _
 %  X and Y cartesian coords in meters.
-% 
+%
 %     Pi = 3.14159265358979
-%     
+%
 % 'tailor the output to fit the equatorial quadrant as determined by the signs of X and Y
 %     If X >= 0 Then 'longitude is in the W90 thru 0 to E90 hemisphere
 %         XYZ_to_Long = (Atn(Y / X)) * (180 / Pi)
 %     End If
-%     
+%
 %     If X < 0 And Y >= 0 Then 'longitude is in the E90 to E180 quadrant
 %         XYZ_to_Long = ((Atn(Y / X)) * (180 / Pi)) + 180
 %     End If
-%     
+%
 %     If X < 0 And Y < 0 Then 'longitude is in the E180 to W90 quadrant
 %         XYZ_to_Long = ((Atn(Y / X)) * (180 / Pi)) - 180
 %     End If
-%     
-% 
+%
+%
 % End Function
-% 
+%
 % Function XYZ_to_H(X, Y, Z, a, b)
 % 'Convert XYZ to Ellipsoidal Height.
 % 'Input: - _
 %  XYZ cartesian coords (X,Y,Z) and ellipsoid axis dimensions (a & b), all in meters.
-% 
+%
 % 'REQUIRES THE "XYZ_to_Lat" FUNCTION
-% 
+%
 % 'Compute PHI (Dec Degrees) first
 %     PHI = XYZ_to_Lat(X, Y, Z, a, b)
-% 
+%
 % 'Convert PHI radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
-%     
+%
 % 'Compute H
 %     RootXYSqr = Sqr((X ^ 2) + (Y ^ 2))
 %     e2 = ((a ^ 2) - (b ^ 2)) / (a ^ 2)
 %     V = a / (Sqr(1 - (e2 * ((Sin(RadPHI)) ^ 2))))
 %     H = (RootXYSqr / Cos(RadPHI)) - V
-%     
+%
 %     XYZ_to_H = H
-%     
+%
 % End Function

--- a/matlab/lib/map_geod2ecef.m
+++ b/matlab/lib/map_geod2ecef.m
@@ -1,6 +1,6 @@
 function [xyz ell] = map_geod2ecef(llh, ell)
 % MAP_GEOD2ECEF Convert points from geodetic system to ECEF system.
-%   [XYZ ELL] = MAP_GEOD2ECEF(LLH, ELL) converts points from a geodetic system 
+%   [XYZ ELL] = MAP_GEOD2ECEF(LLH, ELL) converts points from a geodetic system
 %   to ECEF system.
 %
 %   Inputs:
@@ -19,7 +19,7 @@ function [xyz ell] = map_geod2ecef(llh, ell)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -31,7 +31,7 @@ function [xyz ell] = map_geod2ecef(llh, ell)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -90,56 +90,56 @@ end
 % 'Input: - _
 %  Latitude (PHI)& Longitude (LAM) both in decimal degrees; _
 %  Ellipsoidal height (H) and ellipsoid axis dimensions (a & b) all in meters.
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
 %     RadLAM = LAM * (Pi / 180)
-% 
+%
 % 'Compute eccentricity squared and nu
 %     e2 = ((a ^ 2) - (b ^ 2)) / (a ^ 2)
 %     V = a / (Sqr(1 - (e2 * ((Sin(RadPHI)) ^ 2))))
-% 
+%
 % 'Compute X
 %     Lat_Long_H_to_X = (V + H) * (Cos(RadPHI)) * (Cos(RadLAM))
-% 
+%
 % End Function
-% 
+%
 % Function Lat_Long_H_to_Y(PHI, LAM, H, a, b)
 % 'Convert geodetic coords lat (PHI), long (LAM) and height (H) to cartesian Y coordinate.
 % 'Input: - _
 %  Latitude (PHI)& Longitude (LAM) both in decimal degrees; _
 %  Ellipsoidal height (H) and ellipsoid axis dimensions (a & b) all in meters.
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
 %     RadLAM = LAM * (Pi / 180)
-% 
+%
 % 'Compute eccentricity squared and nu
 %     e2 = ((a ^ 2) - (b ^ 2)) / (a ^ 2)
 %     V = a / (Sqr(1 - (e2 * ((Sin(RadPHI)) ^ 2))))
-% 
+%
 % 'Compute Y
 %     Lat_Long_H_to_Y = (V + H) * (Cos(RadPHI)) * (Sin(RadLAM))
-% 
+%
 % End Function
-% 
+%
 % Function Lat_H_to_Z(PHI, H, a, b)
 % 'Convert geodetic coord components latitude (PHI) and height (H) to cartesian Z coordinate.
 % 'Input: - _
 %  Latitude (PHI) decimal degrees; _
 %  Ellipsoidal height (H) and ellipsoid axis dimensions (a & b) all in meters.
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
-% 
+%
 % 'Compute eccentricity squared and nu
 %     e2 = ((a ^ 2) - (b ^ 2)) / (a ^ 2)
 %     V = a / (Sqr(1 - (e2 * ((Sin(RadPHI)) ^ 2))))
-% 
+%
 % 'Compute X
 %     Lat_H_to_Z = ((V * (1 - e2)) + H) * (Sin(RadPHI))
-% 
+%
 % End Function

--- a/matlab/lib/map_geod2pmap.m
+++ b/matlab/lib/map_geod2pmap.m
@@ -21,7 +21,7 @@ function [enh ell pro] = map_geod2pmap(llh, ell, pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [enh ell pro] = map_geod2pmap(llh, ell, pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_geod2pmap_tm.m
+++ b/matlab/lib/map_geod2pmap_tm.m
@@ -22,7 +22,7 @@ function [enh ell pro] = map_geod2pmap_tm(llh, ell, pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [enh ell pro] = map_geod2pmap_tm(llh, ell, pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -85,7 +85,7 @@ eta2 = nr-1;
 lamd = lam-l0;
 lamd = angle(exp(1i*lamd));
 lamd2 = lamd.^2;
-  
+
 %%
 
 e = e0 + lamd.*nu.*cphi.*(1 ...
@@ -116,14 +116,14 @@ end
 %  eastings of false origin (e0) in meters; _
 %  central meridian scale factor (f0); _
 %  latitude (PHI0) and longitude (LAM0) of false origin in decimal degrees.
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
 %     RadLAM = LAM * (Pi / 180)
 %     RadPHI0 = PHI0 * (Pi / 180)
 %     RadLAM0 = LAM0 * (Pi / 180)
-% 
+%
 %     af0 = a * f0
 %     bf0 = b * f0
 %     e2 = ((af0 ^ 2) - (bf0 ^ 2)) / (af0 ^ 2)
@@ -132,15 +132,15 @@ end
 %     rho = (nu * (1 - e2)) / (1 - (e2 * (Sin(RadPHI)) ^ 2))
 %     eta2 = (nu / rho) - 1
 %     p = RadLAM - RadLAM0
-%     
+%
 %     IV = nu * (Cos(RadPHI))
 %     V = (nu / 6) * ((Cos(RadPHI)) ^ 3) * ((nu / rho) - ((Tan(RadPHI) ^ 2)))
 %     VI = (nu / 120) * ((Cos(RadPHI)) ^ 5) * (5 - (18 * ((Tan(RadPHI)) ^ 2)) + ((Tan(RadPHI)) ^ 4) + (14 * eta2) - (58 * ((Tan(RadPHI)) ^ 2) * eta2))
-%     
+%
 %     Lat_Long_to_East = e0 + (p * IV) + ((p ^ 3) * V) + ((p ^ 5) * VI)
-%     
+%
 % End Function
-% 
+%
 % Function Lat_Long_to_North(PHI, LAM, a, b, e0, n0, f0, PHI0, LAM0)
 % 'Project Latitude and longitude to Transverse Mercator northings
 % 'Input: - _
@@ -149,16 +149,16 @@ end
 %  eastings (e0) and northings (n0) of false origin in meters; _
 %  central meridian scale factor (f0); _
 %  latitude (PHI0) and longitude (LAM0) of false origin in decimal degrees.
-% 
+%
 % 'REQUIRES THE "Marc" FUNCTION
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI = PHI * (Pi / 180)
 %     RadLAM = LAM * (Pi / 180)
 %     RadPHI0 = PHI0 * (Pi / 180)
 %     RadLAM0 = LAM0 * (Pi / 180)
-%     
+%
 %     af0 = a * f0
 %     bf0 = b * f0
 %     e2 = ((af0 ^ 2) - (bf0 ^ 2)) / (af0 ^ 2)
@@ -168,12 +168,12 @@ end
 %     eta2 = (nu / rho) - 1
 %     p = RadLAM - RadLAM0
 %     M = Marc(bf0, n, RadPHI0, RadPHI)
-%     
+%
 %     I = M + n0
 %     II = (nu / 2) * (Sin(RadPHI)) * (Cos(RadPHI))
 %     III = ((nu / 24) * (Sin(RadPHI)) * ((Cos(RadPHI)) ^ 3)) * (5 - ((Tan(RadPHI)) ^ 2) + (9 * eta2))
 %     IIIA = ((nu / 720) * (Sin(RadPHI)) * ((Cos(RadPHI)) ^ 5)) * (61 - (58 * ((Tan(RadPHI)) ^ 2)) + ((Tan(RadPHI)) ^ 4))
-%     
+%
 %     Lat_Long_to_North = I + ((p ^ 2) * II) + ((p ^ 4) * III) + ((p ^ 6) * IIIA)
-%    
+%
 % End Function

--- a/matlab/lib/map_global2plocal.m
+++ b/matlab/lib/map_global2plocal.m
@@ -28,7 +28,7 @@ function [enh dat] = map_global2plocal(llh, dat)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -40,7 +40,7 @@ function [enh dat] = map_global2plocal(llh, dat)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_intro.m
+++ b/matlab/lib/map_intro.m
@@ -92,11 +92,11 @@ function [] = map_intro()
 %       .e0 false easting (default: 0)
 %       .n0 false northing (default: 0)
 %
-%           If the zone substring is defined, 
+%           If the zone substring is defined,
 %           - the numeric PROJ parameter l0 is overwritten by the center
 %             meridian defined by the zone substring (TM),
 %           - all numeric PROJ parameters are overwritten (otherwise)
-% 
+%
 %   Units   all data is defined in SI units (m, rad)
 %
 %   See also MAP_CHECK_ELLI, MAP_CHECK_PROJ, MAP_CHECK_TRAN,
@@ -105,7 +105,7 @@ function [] = map_intro()
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -117,7 +117,7 @@ function [] = map_intro()
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_plocal2global.m
+++ b/matlab/lib/map_plocal2global.m
@@ -1,7 +1,7 @@
 function [llh dat] = map_plocal2global(enh, dat)
 % MAP_LOCAL2GLOBL Backward projection: projected local to global.
 %   [LLH DAT] = MAP_LOCAL2GLOBL(ENH, DAT) converts points from
-%   local map coordinates to global geodetic coordinates by backward projection 
+%   local map coordinates to global geodetic coordinates by backward projection
 %   on a local ellipsoid and datum transformation from a local to global
 %   ellipsoid.
 %
@@ -29,7 +29,7 @@ function [llh dat] = map_plocal2global(enh, dat)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -41,7 +41,7 @@ function [llh dat] = map_plocal2global(enh, dat)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/map_pmap2geod_tm.m
+++ b/matlab/lib/map_pmap2geod_tm.m
@@ -22,7 +22,7 @@ function [llh ell pro] = map_pmap2geod_tm(enh, ell, pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -34,7 +34,7 @@ function [llh ell pro] = map_pmap2geod_tm(enh, ell, pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -98,7 +98,7 @@ lam = angle(exp(1i*lam));
 %%
 
 llh = [phi' lam' enh(:,3)];
-    
+
 end
 % All above formulas are mainly based on the Ordnance Survey publication:
 % http://www.ordnancesurvey.co.uk/oswebsite/gps/ ...
@@ -115,38 +115,38 @@ end
 %  eastings (e0) and northings (n0) of false origin in meters; _
 %  central meridian scale factor (f0) and _
 %  latitude (PHI0) and longitude (LAM0) of false origin in decimal degrees.
-% 
+%
 % 'REQUIRES THE "Marc" AND "InitialLat" FUNCTIONS
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI0 = PHI0 * (Pi / 180)
 %     RadLAM0 = LAM0 * (Pi / 180)
-% 
+%
 % 'Compute af0, bf0, e squared (e2), n and Et
 %     af0 = a * f0
 %     bf0 = b * f0
 %     e2 = ((af0 ^ 2) - (bf0 ^ 2)) / (af0 ^ 2)
 %     n = (af0 - bf0) / (af0 + bf0)
 %     Et = East - e0
-% 
+%
 % 'Compute initial value for latitude (PHI) in radians
 %     PHId = InitialLat(North, n0, af0, RadPHI0, n, bf0)
-%     
+%
 % 'Compute nu, rho and eta2 using value for PHId
 %     nu = af0 / (Sqr(1 - (e2 * ((Sin(PHId)) ^ 2))))
 %     rho = (nu * (1 - e2)) / (1 - (e2 * (Sin(PHId)) ^ 2))
 %     eta2 = (nu / rho) - 1
-%     
+%
 % 'Compute Latitude
 %     VII = (Tan(PHId)) / (2 * rho * nu)
 %     VIII = ((Tan(PHId)) / (24 * rho * (nu ^ 3))) * (5 + (3 * ((Tan(PHId)) ^ 2)) + eta2 - (9 * eta2 * ((Tan(PHId)) ^ 2)))
 %     IX = ((Tan(PHId)) / (720 * rho * (nu ^ 5))) * (61 + (90 * ((Tan(PHId)) ^ 2)) + (45 * ((Tan(PHId)) ^ 4)))
-%     
+%
 %     E_N_to_Lat = (180 / Pi) * (PHId - ((Et ^ 2) * VII) + ((Et ^ 4) * VIII) - ((Et ^ 6) * IX))
-% 
+%
 % End Function
-% 
+%
 % Function E_N_to_Long(East, North, a, b, e0, n0, f0, PHI0, LAM0)
 % 'Un-project Transverse Mercator eastings and northings back to longitude.
 % 'Input: - _
@@ -155,35 +155,35 @@ end
 %  eastings (e0) and northings (n0) of false origin in meters; _
 %  central meridian scale factor (f0) and _
 %  latitude (PHI0) and longitude (LAM0) of false origin in decimal degrees.
-% 
+%
 % 'REQUIRES THE "Marc" AND "InitialLat" FUNCTIONS
-% 
+%
 % 'Convert angle measures to radians
 %     Pi = 3.14159265358979
 %     RadPHI0 = PHI0 * (Pi / 180)
 %     RadLAM0 = LAM0 * (Pi / 180)
-% 
+%
 % 'Compute af0, bf0, e squared (e2), n and Et
 %     af0 = a * f0
 %     bf0 = b * f0
 %     e2 = ((af0 ^ 2) - (bf0 ^ 2)) / (af0 ^ 2)
 %     n = (af0 - bf0) / (af0 + bf0)
 %     Et = East - e0
-% 
+%
 % 'Compute initial value for latitude (PHI) in radians
 %     PHId = InitialLat(North, n0, af0, RadPHI0, n, bf0)
-%     
+%
 % 'Compute nu, rho and eta2 using value for PHId
 %     nu = af0 / (Sqr(1 - (e2 * ((Sin(PHId)) ^ 2))))
 %     rho = (nu * (1 - e2)) / (1 - (e2 * (Sin(PHId)) ^ 2))
 %     eta2 = (nu / rho) - 1
-%     
+%
 % 'Compute Longitude
 %     X = ((Cos(PHId)) ^ -1) / nu
 %     XI = (((Cos(PHId)) ^ -1) / (6 * (nu ^ 3))) * ((nu / rho) + (2 * ((Tan(PHId)) ^ 2)))
 %     XII = (((Cos(PHId)) ^ -1) / (120 * (nu ^ 5))) * (5 + (28 * ((Tan(PHId)) ^ 2)) + (24 * ((Tan(PHId)) ^ 4)))
 %     XIIA = (((Cos(PHId)) ^ -1) / (5040 * (nu ^ 7))) * (61 + (662 * ((Tan(PHId)) ^ 2)) + (1320 * ((Tan(PHId)) ^ 4)) + (720 * ((Tan(PHId)) ^ 6)))
-% 
+%
 %     E_N_to_Long = (180 / Pi) * (RadLAM0 + (Et * X) - ((Et ^ 3) * XI) + ((Et ^ 5) * XII) - ((Et ^ 7) * XIIA))
-% 
+%
 % End Function

--- a/matlab/lib/map_ptm_north2initiallat.m
+++ b/matlab/lib/map_ptm_north2initiallat.m
@@ -1,6 +1,6 @@
 function [phi ell pro] = map_ptm_north2initiallat(north, ell, pro)
 % MAP_PTM_NORTH2INITIALLAT Transverse mercator utility function.
-%   [PHI ELL PRO] = MAP_PTM_NORTH2INITIALLAT(PHI, ELL, PRO) computes the 
+%   [PHI ELL PRO] = MAP_PTM_NORTH2INITIALLAT(PHI, ELL, PRO) computes the
 %   initial latitude values needed for the transverse mercator projections.
 %
 %   Inputs:
@@ -21,7 +21,7 @@ function [phi ell pro] = map_ptm_north2initiallat(north, ell, pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [phi ell pro] = map_ptm_north2initiallat(north, ell, pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -75,13 +75,13 @@ m = 10;
 while i < m
     phi = phi + (nn0-marc)/(a*f0);
     marc = map_ptm_phi2marc(phi, ell, pro);
-    
+
     mabs = max(abs(nn0-marc));
-    
+
     if mabs < 2*aeps
         break
     end
-    
+
     i = i+1;
 end
 
@@ -106,27 +106,27 @@ end
 %  latitude of false origin (PHI0) IN RADIANS; _
 %  n (computed from a, b and f0) and _
 %  ellipsoid semi major axis multiplied by central meridian scale factor (bf0) in meters.
-%  
+%
 % 'REQUIRES THE "Marc" FUNCTION
 % 'THIS FUNCTION IS CALLED BY THE "E_N_to_Lat", "E_N_to_Long" and "E_N_to_C" FUNCTIONS
 % 'THIS FUNCTION IS ALSO USED ON IT'S OWN IN THE  "Projection and Transformation Calculations.xls" SPREADSHEET
-% 
+%
 % 'First PHI value (PHI1)
 %     PHI1 = ((North - n0) / afo) + PHI0
-%     
+%
 % 'Calculate M
 %     M = Marc(bfo, n, PHI0, PHI1)
-%     
+%
 % 'Calculate new PHI value (PHI2)
 %     PHI2 = ((North - n0 - M) / afo) + PHI1
-%     
+%
 % 'Iterate to get final value for InitialLat
 %     Do While Abs(North - n0 - M) > 0.00001
 %         PHI2 = ((North - n0 - M) / afo) + PHI1
 %         M = Marc(bfo, n, PHI0, PHI2)
 %         PHI1 = PHI2
 %     Loop
-%     
+%
 %     InitialLat = PHI2
-%     
+%
 % End Function

--- a/matlab/lib/map_ptm_phi2marc.m
+++ b/matlab/lib/map_ptm_phi2marc.m
@@ -1,6 +1,6 @@
 function [marc ell pro] = map_ptm_phi2marc(phi, ell, pro)
 % MAP_PTM_ENH2LLH Transverse mercator utility function: meridional arc.
-%   [MARC ELL PRO] = MAP_PTM_PHI2MARC(PHI, ELL, PRO) computes the 
+%   [MARC ELL PRO] = MAP_PTM_PHI2MARC(PHI, ELL, PRO) computes the
 %   meridional arc needed for transverse mercator projections.
 %
 %   Inputs:
@@ -21,7 +21,7 @@ function [marc ell pro] = map_ptm_phi2marc(phi, ell, pro)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -33,7 +33,7 @@ function [marc ell pro] = map_ptm_phi2marc(phi, ell, pro)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -88,14 +88,14 @@ end
 %  ellipsoid semi major axis multiplied by central meridian scale factor (bf0) in meters; _
 %  n (computed from a, b and f0); _
 %  lat of false origin (PHI0) and initial or final latitude of point (PHI) IN RADIANS.
-% 
+%
 % 'THIS FUNCTION IS CALLED BY THE - _
 %  "Lat_Long_to_North" and "InitialLat" FUNCTIONS
 % 'THIS FUNCTION IS ALSO USED ON IT'S OWN IN THE "Projection and Transformation Calculations.xls" SPREADSHEET
-% 
+%
 %     Marc = bf0 * (((1 + n + ((5 / 4) * (n ^ 2)) + ((5 / 4) * (n ^ 3))) * (PHI - PHI0)) _
 %     - (((3 * n) + (3 * (n ^ 2)) + ((21 / 8) * (n ^ 3))) * (Sin(PHI - PHI0)) * (Cos(PHI + PHI0))) _
 %     + ((((15 / 8) * (n ^ 2)) + ((15 / 8) * (n ^ 3))) * (Sin(2 * (PHI - PHI0))) * (Cos(2 * (PHI + PHI0)))) _
 %     - (((35 / 24) * (n ^ 3)) * (Sin(3 * (PHI - PHI0))) * (Cos(3 * (PHI + PHI0)))))
-% 
+%
 % End Function

--- a/matlab/lib/map_wgs2html.m
+++ b/matlab/lib/map_wgs2html.m
@@ -46,7 +46,7 @@ function [file] = map_wgs2html(llh, file, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -58,13 +58,13 @@ function [file] = map_wgs2html(llh, file, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
 % *****************************************************************
 
-%% process required arguments 
+%% process required arguments
 
 lc = iscell(llh);
 if lc
@@ -238,7 +238,7 @@ else
         else
             beg_pu{ic} = '<h4>Start of Track:</h4>'; %#ok<AGROW>
         end
-        
+
         if(~isempty(wgs{ic}))
             beg_pu{ic} = [beg_pu{ic} '<table style=\"text-align:right\"><tbody>' ...
                 '<tr><td>lat =</td><td>' num2str(wgs{ic}(1,1),'%.6f') '</td></tr>' ...
@@ -250,7 +250,7 @@ else
         else
             beg_pu{ic} = []; %#ok<AGROW>
         end
-        
+
     end
 end
 
@@ -379,11 +379,11 @@ fprintf(fid, '      }\n');
 fprintf(fid, '      let vectorSource = new ol.source.Vector({});\n');
 
 for ic = 1:nc
-    
+
     if isempty(wgs{ic})
         continue;
     end
-    
+
 
     fprintf(fid, '      let startPoint%u = new ol.Feature({\n', ic);
     fprintf(fid, '        geometry: new ol.geom.Point(ol.proj.fromLonLat([%.6f, %.6f])),\n', wgs{ic}(1,2), wgs{ic}(1,1));

--- a/matlab/lib/sdf_add.m
+++ b/matlab/lib/sdf_add.m
@@ -18,7 +18,7 @@ function [sdf_out] = sdf_add(sdf_in, blockname, sdf_block)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [sdf_out] = sdf_add(sdf_in, blockname, sdf_block)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/sdf_cut.m
+++ b/matlab/lib/sdf_cut.m
@@ -18,7 +18,7 @@ function [sdf_block, sdf_out] = sdf_cut(sdf_in, blockname)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -30,7 +30,7 @@ function [sdf_block, sdf_out] = sdf_cut(sdf_in, blockname)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/smooth_firfilt.m
+++ b/matlab/lib/smooth_firfilt.m
@@ -43,7 +43,7 @@ function [y] = smooth_firfilt(x, w, opts)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -55,7 +55,7 @@ function [y] = smooth_firfilt(x, w, opts)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/lib/str_num2strn.m
+++ b/matlab/lib/str_num2strn.m
@@ -28,7 +28,7 @@ function t = str_num2strn(x, n)
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -40,7 +40,7 @@ function t = str_num2strn(x, n)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/readme.txt
+++ b/matlab/readme.txt
@@ -29,7 +29,7 @@ all 64bit installations, there is virtually no limitation in CRG size.
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -41,7 +41,7 @@ all 64bit installations, there is virtually no limitation in CRG size.
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_append.m
+++ b/matlab/test/crg_test_append.m
@@ -9,7 +9,7 @@
 %
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -21,7 +21,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_continuesTrack.m
+++ b/matlab/test/crg_test_continuesTrack.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_curvature.m
+++ b/matlab/test/crg_test_curvature.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -28,7 +28,7 @@
 % * Test global & local curvature
 % * Test writing and reading flag:
 %   'data.opts.wcvl' <-> 'warn_curv_local'
-% * .. 
+% * ..
 %
 
 % DEFAULT SETTINGS

--- a/matlab/test/crg_test_eval_uv2iuiv.m
+++ b/matlab/test/crg_test_eval_uv2iuiv.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_ext_sb.m
+++ b/matlab/test/crg_test_ext_sb.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_filter.m
+++ b/matlab/test/crg_test_filter.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_gen_csb2crg0.m
+++ b/matlab/test/crg_test_gen_csb2crg0.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_gen_road.m
+++ b/matlab/test/crg_test_gen_road.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_isequal.m
+++ b/matlab/test/crg_test_isequal.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_limiter.m
+++ b/matlab/test/crg_test_limiter.m
@@ -9,7 +9,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -21,7 +21,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_map_pro.m
+++ b/matlab/test/crg_test_map_pro.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %
@@ -66,7 +66,7 @@ web('crg_refline_Hoki_HoeKi_Grafing_approx.html', '-browser');
 %% Test2 ( add map pro entry and check data consistency)
 
 % removing all remaining wgs84 coordinates (for test purposes only)
-crg_orig.head = rmfield(crg_orig.head,'ebeg');   
+crg_orig.head = rmfield(crg_orig.head,'ebeg');
 crg_orig.head = rmfield(crg_orig.head,'nbeg');
 
 % copy data and change file name

--- a/matlab/test/crg_test_map_uv2uvAxy2xy.m
+++ b/matlab/test/crg_test_map_uv2uvAxy2xy.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_options.m
+++ b/matlab/test/crg_test_options.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_peakfinder.m
+++ b/matlab/test/crg_test_peakfinder.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/crg_test_rerender.m
+++ b/matlab/test/crg_test_rerender.m
@@ -5,7 +5,7 @@
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -17,7 +17,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %

--- a/matlab/test/readme.txt
+++ b/matlab/test/readme.txt
@@ -17,7 +17,7 @@ under Matlab for more help.
 
 % *****************************************************************
 % See the NOTICE file distributed with this work regarding copyright ownership.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
@@ -29,7 +29,7 @@ under Matlab for more help.
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 % See the License for the specific language governing permissions and
 % limitations under the License.
-% 
+%
 % More Information on ASAM OpenCRG can be found here:
 % https://www.asam.net/standards/detail/opencrg/
 %


### PR DESCRIPTION
Will make it easier to work with the files using editors that remove whitespace at end of line.

Checked using `git diff --cached --ignore-space-at-eol`.