### PR TITLE
C-API: add geographic and projection header keywords as no-op

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -1436,11 +1436,11 @@ parseFileHeader( CrgDataStruct* crgData, char **dataPtr, size_t* nBytesLeft )
             case dFileSectionFile:
                 cbs = sLoaderCallbacksFile;
                 break;
-                
+
             case dFileSectionRoadCrgMpro:
                 cbs = sLoaderCallbacksMpro;
                 break;
-                
+
             default:
                 cbs = sLoaderCallbacksCommon;
                 break;


### PR DESCRIPTION
When reading a crg file containing refline lat/lon/alt or mpro keywords, the C-API prints warnings that they are unknown keywords and will be ignored. These keywords are well defined by the specification and should not be considered unknown.
Encountering the keywords leads to no-op after merging this PR, which suppresses the warnings.
Then it exhibits the same behaviour as it used to for the channel offsets.

Resolves: #4 