### PR TITLE
crgStrBeginsWithStrNoCase: no undefined behaviour on non-ascii characters

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -3152,25 +3152,25 @@ crgLoaderAddFile( const char* filename, CrgDataStruct** crgRetData )
 static int
 crgStrBeginsWithStrNoCase( const char* str1, const char* str2 )
 {
-	char* c1 = ( char* ) str1;
-	char* c2 = ( char* ) str2;
-	unsigned int i;
+    const char* c1 = str1;
+    const char* c2 = str2;
+    unsigned int i;
 
-	if ( !str1 || !str2 )
-		return 0;
+    if ( !str1 || !str2 )
+        return 0;
 
-	if ( strlen( str1 ) < strlen( str2 ) )
-		return 0;
+    if ( strlen( str1 ) < strlen( str2 ) )
+        return 0;
 
-	for ( i = 0; i < strlen( str2 ); i++ )
-	{
-		if ( tolower( *c1 ) != tolower( *c2 ) )
-			return 0;
+    for ( i = 0; i < strlen( str2 ); i++ )
+    {
+        if ( tolower( (unsigned char) *c1 ) != tolower( (unsigned char) *c2 ) )
+            return 0;
 
-		c1++;
-		c2++;
-	}
-	return 1;
+        c1++;
+        c2++;
+    }
+    return 1;
 }
 
 static void


### PR DESCRIPTION
tolower is not defined for char values less than 0 (relevant on architectures where char is signed). This means arbitrary things could happen if a non-ascii unicode char was passed to this function. Avoid this by casting to unsigned char.

Also switch from tabs to spaces, to align the function to the general coding style.