### PR TITLE
Correct function signature of scanTagsForCallback

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -135,7 +135,7 @@ static int terminateReader( CrgDataStruct* crgData, int retCode );
 * @param opcode     the opcode resulting from the found callback
 * @return the callback method or NULL if none was found
 */
-static int  ( *scanTagsForCallback( const char* buffer, CrgReaderCallbackStruct* cbs, int* opcode ) ) ();
+static int  ( *scanTagsForCallback( const char* buffer, CrgReaderCallbackStruct* cbs, int* opcode ) )( CrgDataStruct*, const char*, int ) ;
 
 /**
 * check whether the first tag contained in the buffer is and "end-of-section" tag
@@ -609,7 +609,7 @@ terminateReader( CrgDataStruct *crgData, int retCode )
 }
 
 
-static int ( *scanTagsForCallback( const char* buffer, CrgReaderCallbackStruct* cbs, int* opcode ) ) ()
+static int ( *scanTagsForCallback( const char* buffer, CrgReaderCallbackStruct* cbs, int* opcode ) )( CrgDataStruct*, const char*, int )
 {
     const char* checkPtr = buffer;
 
@@ -629,7 +629,7 @@ static int ( *scanTagsForCallback( const char* buffer, CrgReaderCallbackStruct* 
         if ( crgStrBeginsWithStrNoCase( checkPtr, cbs->tag ) )
         {
             *opcode = cbs->opcode;
-            return ( int( * ) () ) ( cbs->func );
+            return cbs->func;
         }
         ++cbs;
     }
@@ -1457,7 +1457,7 @@ parseFileHeader( CrgDataStruct* crgData, char **dataPtr, size_t* nBytesLeft )
                 if ( isComment( buffer ) )
                     break;
 
-                if ( ( func = ( int( * ) ( CrgDataStruct*, const char*, int ) ) ( scanTagsForCallback( buffer, cbs, &opcode ) ) ) )
+                if ( ( func = scanTagsForCallback( buffer, cbs, &opcode ) ) )
                 {
                     if ( !func( crgData, buffer, opcode ) )
                         crgMsgPrint( dCrgMsgLevelWarn, "parseFileHeader: Error parsing line %d.\n", lineOfFile );


### PR DESCRIPTION
Makes the code more type-safe.