### PR TITLE
Fix c-api/test portability issue 

### DIFF
--- a/c-api/cmake/OpenCRGCompilerSettings.cmake
+++ b/c-api/cmake/OpenCRGCompilerSettings.cmake
@@ -11,7 +11,7 @@ if(NOT TARGET OpenCRGCompilerSettings)
 
     # Set warning flags
     target_compile_options(OpenCRGCompilerSettings INTERFACE
-        $<$<C_COMPILER_ID:MSVC>:/W4>
+        $<$<C_COMPILER_ID:MSVC>:/W4 /wd4996>
         $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wall -Wextra>
     )
 

--- a/c-api/test/CMakeLists.txt
+++ b/c-api/test/CMakeLists.txt
@@ -11,12 +11,8 @@ endif()
 
 add_subdirectory(Dump)
 add_subdirectory(MemTest)
+add_subdirectory(MultiCp)
+add_subdirectory(MultiRead)
+add_subdirectory(PerfTest)
 add_subdirectory(Scan)
 add_subdirectory(Verify)
-
-# The following source files use non-portable code
-if(UNIX)
-    add_subdirectory(MultiCp)
-    add_subdirectory(MultiRead)
-    add_subdirectory(PerfTest)
-endif()

--- a/c-api/test/Dump/src/main.c
+++ b/c-api/test/Dump/src/main.c
@@ -47,8 +47,8 @@ int main( int argc, char** argv )
     FILE*          fPtr      = NULL;
     CrgDataStruct* crgData   = NULL;
     int            dataSetId = 0;
-    int            i;
-    int            j;
+    size_t         i;
+    size_t         j;
     int            cpId;
     int            count;
     int            resolution;
@@ -167,7 +167,7 @@ int main( int argc, char** argv )
 
         for ( j = 0; j < crgData->channelV.info.size; j += resolution )
         {
-            int index = j;
+            size_t index = j;
 
             if ( count % 2 )
                 index = crgData->channelV.info.size - 1 - index;

--- a/c-api/test/MultiCp/src/main.c
+++ b/c-api/test/MultiCp/src/main.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <sys/time.h>
+#include <time.h>
 #include "crgBaseLibPrivate.h"
 
 
@@ -40,6 +40,12 @@ void usage()
     crgMsgPrint( dCrgMsgLevelNotice, "                -d      enable debug mode\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "       <filename> use indicated file as input file\n" );
     exit( -1 );
+}
+
+double get_time_seconds(void) {
+    struct timespec ts;
+    timespec_get(&ts, TIME_UTC);
+    return ts.tv_sec + 1.0e-9 * ts.tv_nsec;
 }
 
 int main( int argc, char** argv )
@@ -101,9 +107,8 @@ int main( int argc, char** argv )
     int    noTestPts;       /* size of the test point array                */
     int    idxTestPt;       /* test point index                            */
 
-    struct timeval tme;     /* measure the run-time                        */
-    double startTime;       /* [s]                                         */
-    double endTime;         /* [s]                                         */
+    double startTime;       /* query timer start [s]                       */
+    double endTime;         /* query timer end   [s]                       */
 
     /* --- decode the command line --- */
     if ( argc < 2 )
@@ -300,8 +305,7 @@ int main( int argc, char** argv )
     crgContactPointActivatePerfStat( cpId );
 
     /* --- all right, I have the test points, now let's go through all of them and measure the time required --- */
-    gettimeofday(&tme, 0);
-    startTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    startTime = get_time_seconds();
 
     idxTestPt = 0;
     cpIdx     = 0;
@@ -326,8 +330,7 @@ int main( int argc, char** argv )
             cpIdx = 0;
     }
 
-    gettimeofday(&tme, 0);
-    endTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    endTime = get_time_seconds();
 
     crgMsgPrint( dCrgMsgLevelWarn, "main: total time for %d queries: %.3lf seconds (i.e. %.3lfus per query)\n",  noTestPts, endTime - startTime, ( endTime - startTime ) / noTestPts * 1.0e6 );
 

--- a/c-api/test/MultiRead/src/main.c
+++ b/c-api/test/MultiRead/src/main.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <sys/time.h>
+#include <time.h>
 #include "crgBaseLib.h"
 
 
@@ -37,6 +37,12 @@ void usage()
     crgMsgPrint( dCrgMsgLevelNotice, "       options: -h    show this info\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "       <filename> use indicated file as input file\n" );
     exit( -1 );
+}
+
+double get_time_seconds(void) {
+    struct timespec ts;
+    timespec_get(&ts, TIME_UTC);
+    return ts.tv_sec + 1.0e-9 * ts.tv_nsec;
 }
 
 int main( int argc, char** argv )
@@ -93,9 +99,8 @@ int main( int argc, char** argv )
     int    noTestPts;       /* size of the test point array                */
     int    idxTestPt;       /* test point index                            */
 
-    struct timeval tme;     /* measure the run-time                        */
-    double startTime;       /* [s]                                         */
-    double endTime;         /* [s]                                         */
+    double startTime;       /* query timer start [s]                       */
+    double endTime;         /* query timer end   [s]                       */
 
     /* --- decode the command line --- */
     if ( argc < 2 )
@@ -255,8 +260,7 @@ int main( int argc, char** argv )
     crgMsgPrint( dCrgMsgLevelNotice, "main: generated %d test points. Now running actual test....\n", idxTestPt );
 
     /* --- all right, I have the test points, now let's go through all of them and measure the time required --- */
-    gettimeofday(&tme, 0);
-    startTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    startTime = get_time_seconds();
 
     idxTestPt = 0;
 
@@ -274,8 +278,7 @@ int main( int argc, char** argv )
         idxTestPt++;
     }
 
-    gettimeofday(&tme, 0);
-    endTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    endTime = get_time_seconds();
 
     crgMsgPrint( dCrgMsgLevelWarn, "main: total time for %d queries: %.3lf seconds (i.e. %.3lfus per query)\n",  noTestPts, endTime - startTime, ( endTime - startTime ) / noTestPts * 1.0e6 );
 

--- a/c-api/test/PerfTest/src/main.c
+++ b/c-api/test/PerfTest/src/main.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#include <sys/time.h>
+#include <time.h>
 #include "crgBaseLibPrivate.h"
 
 
@@ -37,6 +37,12 @@ void usage()
     crgMsgPrint( dCrgMsgLevelNotice, "       options: -h    show this info\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "       <filename> use indicated file as input file\n" );
     exit( -1 );
+}
+
+double get_time_seconds(void) {
+    struct timespec ts;
+    timespec_get(&ts, TIME_UTC);
+    return ts.tv_sec + 1.0e-9 * ts.tv_nsec;
 }
 
 int main( int argc, char** argv )
@@ -93,9 +99,8 @@ int main( int argc, char** argv )
     size_t noTestPts;       /* size of the test point array                */
     size_t idxTestPt;       /* test point index                            */
 
-    struct timeval tme;     /* measure the run-time                        */
-    double startTime;       /* [s]                                         */
-    double endTime;         /* [s]                                         */
+    double startTime;       /* query timer start [s]                       */
+    double endTime;         /* query timer end   [s]                       */
 
     /* --- decode the command line --- */
     if ( argc < 2 )
@@ -255,8 +260,7 @@ int main( int argc, char** argv )
     crgContactPointActivatePerfStat( cpId );
 
     /* --- all right, I have the test points, now let's go through all of them and measure the time required --- */
-    gettimeofday(&tme, 0);
-    startTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    startTime = get_time_seconds();
 
     idxTestPt = 0;
 
@@ -274,8 +278,7 @@ int main( int argc, char** argv )
         idxTestPt++;
     }
 
-    gettimeofday(&tme, 0);
-    endTime = tme.tv_sec + 1.0e-6 * tme.tv_usec;
+    endTime = get_time_seconds();
 
     crgMsgPrint( dCrgMsgLevelWarn, "main: total time for %zu queries: %.3lf seconds (i.e. %.3lfus per query)\n",  noTestPts, endTime - startTime, ( endTime - startTime ) / noTestPts * 1.0e6 );
 


### PR DESCRIPTION
Header file sys/time.h only exists for UNIX like
platforms. Replaced it with time.h using timespec_get to get current time.
Also fixed a compiler warning in crgDump.

Resolves: #86