### PR TITLE
c-api: deactivate warning C4996 for MSVC

### DIFF
--- a/c-api/cmake/OpenCRGCompilerSettings.cmake
+++ b/c-api/cmake/OpenCRGCompilerSettings.cmake
@@ -11,7 +11,7 @@ if(NOT TARGET OpenCRGCompilerSettings)
 
     # Set warning flags
     target_compile_options(OpenCRGCompilerSettings INTERFACE
-        $<$<C_COMPILER_ID:MSVC>:/W4>
+        $<$<C_COMPILER_ID:MSVC>:/W4 /wd4996>
         $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wall -Wextra>
     )
 


### PR DESCRIPTION
Building with MSVC leads to a lot of deprecation
warnings C4996 for function like strncpy, fopen, ...
Since we make sure that we use them safely, we are not going to replace them.
The warnings are deactivated to unclutter the printed output.