### PR TITLE
c-api: fix minor msvc compiler warnings and a potential overflow

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -1993,7 +1993,7 @@ readData( CrgDataStruct* crgData )
 void
 crgLoaderHandleNaNs( CrgDataStruct* crgData, int mode, double offset )
 {
-    int totalNaN   = 0;
+    size_t totalNaN   = 0;
     size_t minIndexLR = crgData->channelV.info.size;
     size_t maxIndexRL = 0;
     size_t i;
@@ -2098,7 +2098,7 @@ crgLoaderHandleNaNs( CrgDataStruct* crgData, int mode, double offset )
 
     crgMsgPrint( dCrgMsgLevelNotice, "crgLoaderHandleNaNs: Summary of NaN handling information:\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "                     NaNs in crg data replaced by constant extrapolation.\n" );
-    crgMsgPrint( dCrgMsgLevelNotice, "                     total NaNs in data [-]:        %d\n", totalNaN );
+    crgMsgPrint( dCrgMsgLevelNotice, "                     total NaNs in data [-]:        %zu\n", totalNaN );
     crgMsgPrint( dCrgMsgLevelNotice, "                     max. NaN count from left [-]:  %ld\n", crgData->channelV.info.size - minIndexLR );
     crgMsgPrint( dCrgMsgLevelNotice, "                     max. NaN count from right [-]: %ld\n", maxIndexRL );
 }

--- a/c-api/baselib/src/crgStatistics.c
+++ b/c-api/baselib/src/crgStatistics.c
@@ -290,6 +290,7 @@ void crgCalcUtilityData( CrgDataStruct *crgData )
         /*         extension on end of data set within valid area              */
         l     = ( ( a2 - b2 ) * m2 + ( a1 - b1 ) * m1 ) / divisor;
         valid = l > 0.0;
+        k     = 0;
 
         if ( valid )
         {


### PR DESCRIPTION
When counting number of nan values the counter should be of size_t as the other indices are.
This could have also led to a integer overflow for huge elevation data sections with little valid data.

During calculation of utility data, MSVC does not see that variable k is always initialized before use, 
so initialize it to silence warning.