### PR TITLE
40 document that keywords are case insensitive

### DIFF
--- a/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
+++ b/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
@@ -3,15 +3,17 @@
 //TODO bytes as plural or byte as unit?
 //TODO full-stop after image or table titles?
 
-OpenCRG data is stored in a compact hybrid file format. Its first part is a plain text header containing sections for road parameters, data channel definitions, comments and further optional sections. The second part contains the data payload in plain text or binary representation.
+OpenCRG data is stored in a compact hybrid file format. Its first part is a plain text header containing sections for road parameters, data channel definitions, and further optional sections. The second part contains the data payload in plain text or binary representation.
 
 The plain text header shall consist of records with a maximum length of 72 ASCII characters. Any characters beyond the maximum length of 72 bytes shall be ignored. All records shall be terminated by LF or CRLF.
 
 Use of character sets beyond ASCII is limited to comments in the plain text header. Using 8bit character sets like ISO8859-1 or variable byte length character sets like UTF-8 may be possible, but the maximum record length shall be 72 bytes. Any use of non-ASCII characters is strongly discouraged, since the representation of the non-ASCII characters may fail in non-consistent environments. 
 
-All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores`_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. To increase readability, clear text header sections should appear in the sequence recommended in <<tab-recommended_data_section_sequence>>.
+All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores`_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. 
 
 Each plain text header section shall start with a line containing a `$` character as first character followed by a keyword. Each plain text header section shall be terminated by a new line with a single `$` character as first character. The keyword at the beginning of a data section and the closing `$` character at the end of a data section may be followed by inline comments.
+
+Sections labeled by keywords shall be unique inside the plain text header. Parameters labeled by keywords shall be unique inside a section of the plain text header. The order of the sections in the plain text header and the order of parameters within the sections can be arranged in a flexible manner. To increase readability, the clear text header sections may appear in the sequence recommended in <<tab-recommended_data_section_sequence>> and later paragraphs and samples.
 
 The plain text header shall be terminated by a new line with double or multiple `$` as first characters and may be followed by an inline comment. This separator record shall be terminated by LF or CRLF.
 

--- a/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
+++ b/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
@@ -7,7 +7,7 @@ OpenCRG data is stored in a compact hybrid file format. Its first part is a plai
 
 The plain text header shall consist of records with a maximum length of 72 ASCII characters. Any characters beyond the maximum length of 72 bytes shall be ignored. All records shall be terminated by LF or CRLF.
 
-Use of character sets beyond ASCII is limited to comments in the plain text header. Using 8bit character sets like ISO8859-1 or variable byte length character sets like UTF-8 may be possible, but the maximum record length shall be 72 bytes. Any use of non-ASCII characters is strongly discouraged, since the representation of the non-ASCII characters may fail in non-consistent environments. 
+Use of character sets beyond ASCII is limited to comments in the plain text header. Using 8bit character sets like ISO 8859-1 or variable byte length character sets like UTF-8 may be possible, but the maximum record length shall be 72 bytes. Any use of non-ASCII characters is strongly discouraged, since the representation of the non-ASCII characters may fail in non-consistent environments. 
 
 All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores`_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. 
 

--- a/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
+++ b/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
@@ -3,11 +3,19 @@
 //TODO bytes as plural or byte as unit?
 //TODO full-stop after image or table titles?
 
-An OpenCRG file consists of several data sections that represent different aspects of the road surface data described in that file. OpenCRG files are written in plain text using ISO 8859-1 encoding. The actual road data may be provided in a binary format. Each line in a data section is considered a record. Except for the road data section, a record shall have a maximum length of 72 byte for a maximum of 72 characters per record. In the road data section, a record shall have a maximum length of 80 byte.
+OpenCRG data is stored in a compact hybrid file format. Its first part is a plain text header containing sections for road parameters, data channel definitions, comments and further optional sections. The second part contains the data payload in plain text or binary representation.
 
-Each data section shall start with a line containing a `$` character followed by a keyword. Each data section shall be terminated by a new line with a `$` character as first character. The keyword at the beginning of a data section and the closing `$` character at the end of a data section may be followed by inline comments.
+The plain text header shall consist of records with a maximum length of 72 ASCII characters. Any characters beyond the maximum length of 72 bytes shall be ignored. All records shall be terminated by LF or CRLF.
 
-Every OpenCRG file shall start with a header information section, describing the contents of the file. If a road data section is present, it shall be the last section in the OpenCRG file. The sequence of the other data sections is not defined. To increase readability, data sections should appear in the sequence recommended in <<tab-recommended_data_section_sequence>>.
+Use of character sets beyond ASCII is limited to comments in the plain text header. Using 8bit character sets like ISO8859-1 or variable byte length character sets like UTF-8 may be possible, but the maximum record length shall be 72 bytes. Any use of non-ASCII characters is strongly discouraged, since the representation of the non-ASCII characters may fail in non-consistent environments. 
+
+All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores`_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. To increase readability, clear text header sections should appear in the sequence recommended in <<tab-recommended_data_section_sequence>>.
+
+Each plain text header section shall start with a line containing a `$` character as first character followed by a keyword. Each plain text header section shall be terminated by a new line with a single `$` character as first character. The keyword at the beginning of a data section and the closing `$` character at the end of a data section may be followed by inline comments.
+
+The plain text header shall be terminated by a new line with double or multiple `$` as first characters and may be followed by an inline comment. This separator record shall be terminated by LF or CRLF.
+
+The data payload shall consist of clear text records with a maximum length of 80 ASCII characters, terminated by LF or CRLF, or it shall consist of binary records of 80 bytes length without any extra terminators.
 
 [#tab-recommended_data_section_sequence]
 .Overview of data sections in recommended sequence.

--- a/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
+++ b/content/06_opencrg_data_format/3_2_Data_file_structure.adoc
@@ -9,7 +9,7 @@ The plain text header shall consist of records with a maximum length of 72 ASCII
 
 Use of character sets beyond ASCII is limited to comments in the plain text header. Using 8bit character sets like ISO 8859-1 or variable byte length character sets like UTF-8 may be possible, but the maximum record length shall be 72 bytes. Any use of non-ASCII characters is strongly discouraged, since the representation of the non-ASCII characters may fail in non-consistent environments. 
 
-All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores`_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. 
+All keywords used for sections or parameters inside the sections shall follow the rules of a simple variable naming convention: first character is a letter A-Z, next characters are letters A-Z, digits 0-9 and underscores `_`. The maximum keyword length is 31 characters. All keyword letters are treated case-insensitive. 
 
 Each plain text header section shall start with a line containing a `$` character as first character followed by a keyword. Each plain text header section shall be terminated by a new line with a single `$` character as first character. The keyword at the beginning of a data section and the closing `$` character at the end of a data section may be followed by inline comments.
 

--- a/content/06_opencrg_data_format/3_4_7_Road_data.adoc
+++ b/content/06_opencrg_data_format/3_4_7_Road_data.adoc
@@ -46,32 +46,35 @@ None.
 
 ===== Examples
 
-The example shows road data for a 1 m wide road. The road data is organized in a 4-by-10 matrix. The first column contains heading angles of the reference line. The following three columns contain actual road surface data. One value on the right border of the road is missing.
+The example shows road data for a 1 m wide road. The road data is organized in a 4-by-10 matrix. The first column contains heading angles of the reference line, ignoring the first value, starting with the second value to describe the direction from the first to the second reference point. The following three columns contain actual road surface data. One value on the right border of the road is undefined (NaN).
 
 .Plain-text road data with 4 columns and 10 rows
 ----
-$ROAD_CRG                          ! road parameters section
-REFERENCE_LINE_INCREMENT =  0.50   ! 10 cm between every lateral cut
-LONG_SECTION_V_RIGHT     = -0.50   ! right road border
-LONG_SECTION_V_RIGHT     =  0.50   ! left road border
-LONG_SECTION_V_INCREMENT =  0.50   ! 50 cm between every longitudinal cut
-$!********************************
-$KD_DEFINiTION                     ! data definition section
-#:LRBI                             ! plain-text data, numbers of type real
-D:reference line phi,rad           ! heading angle
-D:long section 1,m                 ! 0.50m right of reference line
-D:long section 2,m                 !             on reference line
-D:long section 3,m                 ! 0.50m  left of reference line
-$!********************************
-$
-0.0000000 0.0000000 0.0000000 0.0000000
-0.0000000 0.0000000 0.0000000 0.0000000
-0.0000000 0.0000000 0.0000000 0.0000000
-0.0000000 0.0111111 0.0111111 0.0000000
-0.0000000 0.0000000 0.0000000 0.0000000
-0.0111111 *missing* 0.0000000 0.0111111
-0.0111111 0.0111111 0.0111111 0.0222222
-0.0111111 0.0111111 0.0222222 0.0333333
-0.0111111 0.0111111 0.0111111 0.0222222
-0.0111111 0.0000000 0.0000000 0.0111111
+$ROAD_CRG                         ! road parameters section
+REFERENCE_LINE_INCREMENT =  0.50  ! 50 cm between every lateral cut
+LONG_SECTION_V_RIGHT     = -0.50  ! right road border
+LONG_SECTION_V_RIGHT     =  0.50  ! left road border
+LONG_SECTION_V_INCREMENT =  0.50  ! 50 cm between every longitudinal cut
+$!******10********20********30********40********50********60********70**
+$KD_DEFINiTION                    ! data definition section
+#:LRFI                            ! plain-text data, real numbers
+D:reference line phi,rad          ! heading angle
+D:long section 1,m                ! 0.50m right of reference line
+D:long section 2,m                !             on reference line
+D:long section 3,m                ! 0.50m  left of reference line
+$!******10********20********30********40********50********60********70**
+* Sample payload data, 4 channels as defined by "D:" above:
+* heading   l_sec 1   l_sec 2   l_sec 3
+* angle     v=-0.50   v= 0.00   v= 0.50
+$$!*****10********20********30********40********50********60********70********80
+ *missing* 0.0000000 0.0000000 0.0000000
+ 0.0000000 0.0000000 0.0000000 0.0000000
+-0.0110000 0.0000000 0.0000000 0.0000000
+-0.0110000 0.0111111 0.0111111 0.0000000
+ 0.0000000 0.0000000 0.0000000 0.0000000
+ 0.0110000 *missing* 0.0000000 0.0111111
+ 0.0220000-0.0111111 0.0111111 0.0222222
+ 0.0330000-0.0111111 0.0222222 0.0333333
+ 0.0440000-0.0111111 0.0111111 0.0222222
+ 0.0550000-0.0000000 0.0000000 0.0111111
 ----


### PR DESCRIPTION
Adding the case-insensitivity feature to the documentation motivated to add some more precise descriptions and to fix some bugs in the documented sample CRG file.

This resolves #40 .

But it made visible, that the new ASAM documentation still needs lots of further reviewing and fixing ...