### PR TITLE
Add workflow to create antora documentation in pull requests for review

### DIFF
--- a/.antora/antora.yml
+++ b/.antora/antora.yml
@@ -5,7 +5,7 @@ title: ASAM OpenCRG
 version: 
   v(?<v>+({0..99}).+({0..99}).+({0..99})): $<v>
   v(?<version>+({0..99}).+({0..99}).+({0..99}))-(?<suffix>*): $<version>-$<suffix>
-  main: 'current'
+  master: 'current'
   (*): 'pull-request'
 # CENTRAL DOCUMENT ONLY!!! First page of the component. Define only once per component!
 start_page: specification:index.adoc

--- a/.github/workflows/antora-build-local.yml
+++ b/.github/workflows/antora-build-local.yml
@@ -39,7 +39,7 @@ jobs:
       uses: docker://ghcr.io/asam-ev/project-guide-docker:4
       with:
         entrypoint: sh
-        args: repo/run-build.sh
+        args: repo/run-build-pr.sh
 
     - name: Upload preview artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/antora-build-local.yml
+++ b/.github/workflows/antora-build-local.yml
@@ -1,0 +1,49 @@
+name: Build documentation (PR preview)
+on:
+  pull_request:
+    types: [ opened, edited, synchronize, reopened ]
+  workflow_dispatch:
+
+concurrency:
+  group: pr-docs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read  # Only what's needed for checkout
+
+jobs:
+  build:
+    name: Build OpenCRG documentation (PR preview)
+    runs-on: ubuntu-latest
+    services:
+      kroki:
+        image: yuzutech/kroki:0.15.1
+        env:
+          KROKI_MAX_URI_LENGTH: 8000
+          KROKI_BLOCKDIAG_HOST: blockdiag
+          KROKI_MERMAID_HOST: mermaid
+      blockdiag:
+        image: yuzutech/kroki-blockdiag:0.15.1
+      mermaid:
+        image: yuzutech/kroki-mermaid:0.15.1
+
+    steps:
+    - name: Checkout with submodules
+      uses: actions/checkout@v6
+      with:
+        path: repo
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Generate site
+      uses: docker://ghcr.io/asam-ev/project-guide-docker:4
+      with:
+        entrypoint: sh
+        args: repo/run-build.sh
+
+    - name: Upload preview artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-preview-${{ github.event.pull_request.number }}
+        path: ./repo/site
+        retention-days: 7

--- a/antora-playbook-pr.yml
+++ b/antora-playbook-pr.yml
@@ -19,7 +19,7 @@ content:
   - url: .
     start_path: .antora
     tags: ['v*', '!v2.0.0', '!v1.2.1', '!v_1_1_2'] # Exclude old versions that are not build with antora
-    branches: ['master']
+    branches: ['HEAD']
 # end::content[]
 
 ui:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -19,7 +19,7 @@ content:
   - url: .
     start_path: .antora
     tags: ['v*', '!v2.0.0', '!v1.2.1', '!v_1_1_2'] # Exclude old versions that are not build with antora
-    branches: ['master']
+    branches: ['HEAD', 'master']
 # end::content[]
 
 ui:

--- a/run-build-pr.sh
+++ b/run-build-pr.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script is used tackle a some specifics of the GitHub action used with a docker container. 
+# It copies the cached node-modules from the container to the runner workspace and then triggers the build using npm
+
+cp -r /usr/src/repo/. /github/workspace/.
+cd repo
+export NODE_OPTIONS="--max-old-space-size=8192"
+exec antora --stacktrace --fetch --clean antora-playbook-pr.yml


### PR DESCRIPTION
- Fix in the antora configuration file, because the default branch in this repo is master and not main
- Added pipeline to build the antora documentation in a pull request and upload it as an artifact. It can be downloaded from the pull request artifacts and reviewed locally.