### PR TITLE
C API: add new API function `crgContactPointSetHistoryForAllPoints`

### DIFF
--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -456,6 +456,12 @@ extern "C"
     */
     extern int crgContactPointSetHistory( int cpId, int histSize );
 
+    /**
+    * set the size of the history for all contact points
+    * @param histSize  the desired size of the history
+    */
+    extern void crgContactPointSetHistoryForAllPoints( int histSize );
+
 /* ====== METHODS in crgEvalxy2uv.c ====== */
     /**
     * convert a given (x,y) position into the corresponding (u,v) position

--- a/c-api/baselib/src/crgContactPoint.c
+++ b/c-api/baselib/src/crgContactPoint.c
@@ -622,3 +622,14 @@ crgContactPointPrintHistory( CrgContactPointStruct *cp, double x, double y )
 
 }
 
+void
+crgContactPointSetHistoryForAllPoints( int histSize )
+{
+    if ( !cpTable )
+        return;
+
+    for ( int i = 0; i < cpTableSize; i++ )
+    {
+        crgContactPointPtrSetHistory( cpTable[i], histSize );
+    }
+}


### PR DESCRIPTION
Makes it possible to set a uniform history size across all contact points.