### PR TITLE
Add release job to build workflow

### DIFF
--- a/.github/workflows/antora-build-local.yml
+++ b/.github/workflows/antora-build-local.yml
@@ -42,7 +42,7 @@ jobs:
         args: repo/run-build-pr.sh
 
     - name: Upload preview artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs-preview-${{ github.event.pull_request.number }}
         path: ./repo/site

--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -122,6 +122,6 @@ jobs:
           -x ".git/*" ".github/*" "*.gitignore" "*.gitattributes" "*.gitkeep" "*.o" "*.obj" ".a"
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ env.ZIP_NAME }}

--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -83,3 +83,45 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+  release:
+    # Run if triggered by a published release.
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    # Take specification artifact from build job and package into a zip for the release.
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download specification artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+          path: ./artifact-download
+
+      - name: Extract specification
+        run: |
+          mkdir -p ./specification
+          tar -xf ./artifact-download/artifact.tar -C ./specification
+
+      - name: Create zip archive
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          TAG_NAME="${GITHUB_REF_NAME}"
+          ZIP_NAME="${REPO_NAME}-${TAG_NAME}.zip"
+          
+          echo "ZIP_NAME=$ZIP_NAME" >> "$GITHUB_ENV"
+          
+          zip -r "$ZIP_NAME" \
+          c-api crg-bin crg-txt matlab \
+          specification \
+          LICENSE NOTICE README.md RELEASENOTES \
+          -x ".git/*" ".github/*" "*.gitignore" "*.gitattributes" "*.gitkeep" "*.o" "*.obj" ".a"
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ZIP_NAME }}

--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -45,7 +45,7 @@ jobs:
          submodules: recursive
 
     - name: Configure Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
 
     - name: Generate site
       uses: docker://ghcr.io/asam-ev/project-guide-docker:4
@@ -54,7 +54,7 @@ jobs:
         args: repo/run-build.sh # modified based on OSI
 
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: ./repo/site
 
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   release:
     # Run if triggered by a published release.
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download specification artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: github-pages
           path: ./artifact-download


### PR DESCRIPTION
On release, package the specification along with the c and matlab apis in a zip file and attach it as an asset to the release.

You can find an example package in a release in my test repo: https://github.com/Persival-GmbH/OpenCRG/releases/tag/v2.0.14