### PR TITLE
c-api: remove most unreachable code from demo/test sources

### DIFF
--- a/c-api/demo/Curvature/src/main.c
+++ b/c-api/demo/Curvature/src/main.c
@@ -63,7 +63,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data file <%s>.\n", filename );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/demo/EvalOptions/src/main.c
+++ b/c-api/demo/EvalOptions/src/main.c
@@ -36,7 +36,7 @@ void usage()
     crgMsgPrint( dCrgMsgLevelNotice, "       options: -h      show this info\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "                -t <n>  run only test no. <n>\n" );
     crgMsgPrint( dCrgMsgLevelNotice, "                -p      write resulting data to <crgPlotFile.txt>\n" );
-    crgMsgPrint( dCrgMsgLevelNotice, "       <filename>  input file, default: [%s]\n", "../../Data/handmade_straight.crg" );
+    crgMsgPrint( dCrgMsgLevelNotice, "       <filename>  input file, default: [%s]\n", "../../../crg-txt/handmade_straight.crg" );
     exit( -1 );
 }
 

--- a/c-api/demo/EvalOptions/src/main.c
+++ b/c-api/demo/EvalOptions/src/main.c
@@ -68,7 +68,7 @@ int myMsgHandler( int level, char* message )
 
 int main( int argc, char** argv )
 {
-    char*  filename = "../../Data/handmade_straight.crg";
+    char*  filename = "../../../crg-txt/handmade_straight.crg";
     int    dataSetId = 0;
     int    cpId;
     int    testNo = 0;

--- a/c-api/demo/EvalXYnUV/src/main.c
+++ b/c-api/demo/EvalXYnUV/src/main.c
@@ -95,7 +95,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/demo/EvalZ/src/main.c
+++ b/c-api/demo/EvalZ/src/main.c
@@ -97,7 +97,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/demo/Simple/src/main.c
+++ b/c-api/demo/Simple/src/main.c
@@ -67,7 +67,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data file <%s>.\n", filename );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/Dump/src/main.c
+++ b/c-api/test/Dump/src/main.c
@@ -118,7 +118,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/MemTest/src/main.c
+++ b/c-api/test/MemTest/src/main.c
@@ -100,7 +100,6 @@ int main( int argc, char** argv )
         {
             crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
             usage();
-            return -1;
         }
 
         /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/MultiCp/src/main.c
+++ b/c-api/test/MultiCp/src/main.c
@@ -166,7 +166,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/MultiRead/src/main.c
+++ b/c-api/test/MultiRead/src/main.c
@@ -139,7 +139,6 @@ int main( int argc, char** argv )
         {
             crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
             usage();
-            return -1;
         }
 
         /* --- check CRG data for consistency and accuracy --- */
@@ -271,7 +270,7 @@ int main( int argc, char** argv )
 
         /* --- now all the way back and check the result --- */
         if ( !crgEvalxy2z( cpId, testX[idxTestPt], testY[idxTestPt], &z ) )
-            crgMsgPrint( dCrgMsgLevelWarn, "main: error converting x/y = %.3f / %.3f to z.\n",  x, y );
+            crgMsgPrint( dCrgMsgLevelWarn, "main: error converting x/y = %.3f / %.3f to z.\n",  testX[idxTestPt], testY[idxTestPt] );
 
         /* fprintf( stderr, "%.3lf %.3lf %.3lf\n", testX[idxTestPt], testY[idxTestPt], z ); */
 

--- a/c-api/test/PerfTest/src/main.c
+++ b/c-api/test/PerfTest/src/main.c
@@ -137,7 +137,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/Scan/src/main.c
+++ b/c-api/test/Scan/src/main.c
@@ -153,7 +153,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */

--- a/c-api/test/Verify/src/main.c
+++ b/c-api/test/Verify/src/main.c
@@ -113,7 +113,6 @@ int main( int argc, char** argv )
     {
         crgMsgPrint( dCrgMsgLevelFatal, "main: error reading data.\n" );
         usage();
-        return -1;
     }
 
     /* --- check CRG data for consistency and accuracy --- */


### PR DESCRIPTION
The return statement after the call to usage function is unreachable because usage terminates execution.
Also fixed a bug in "MultiRead" were the wrong coordinates were printed in the warning message.