### PR TITLE
C-API: add additive inverse to offsets when applying mods

### DIFF
--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -668,6 +668,7 @@ crgDataOffsetChannel( CrgChannelStruct* channel, double offset )
 
     channel->info.first += offset;
     channel->info.last  += offset;
+    channel->info.offset -= offset;
 }
 
 void
@@ -939,7 +940,6 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
-        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -957,9 +957,6 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
-
-        crgData->channelX.info.offset -= dx;
-        crgData->channelY.info.offset -= dy;
 
         if ( crgData->channelRefZ.info.valid )
         {

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -47,6 +47,13 @@ static void crgDataScaleChannel( CrgChannelBaseStruct* channel, double factor, i
 static void crgDataOffsetChannel( CrgChannelStruct* channel, double offset );
 
 /**
+* offset the data of channelZ or channelRefZ depending on availability
+* @param channel    pointer to data set
+* @param offset     offset value
+*/
+static void crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset);
+
+/**
 * apply any transformation specified by modifiers
 * @param crgData    pointer to data set which is to be modified
 */
@@ -668,7 +675,24 @@ crgDataOffsetChannel( CrgChannelStruct* channel, double offset )
 
     channel->info.first += offset;
     channel->info.last  += offset;
-    channel->info.offset -= offset;
+}
+
+static void
+crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
+{
+    size_t i;
+
+    if (!crgData)
+        return;
+
+    crgData->channelRefZ.info.first  += offset;
+    crgData->channelRefZ.info.last   += offset;
+
+    if (crgData->channelRefZ.info.valid)
+    {
+        for (i = 0; i < crgData->channelRefZ.info.size; i++)
+            crgData->channelRefZ.data[i] += offset;
+    }
 }
 
 void
@@ -789,6 +813,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
     double fromXYZ[3]    = { 0.0, 0.0, 0.0 };
     double toXYZ[3]      = { 0.0, 0.0, 0.0 };
     double rotCenter[2]  = { 0.0, 0.0 };
+    double xyFirst[2]    = { 0.0, 0.0 };
     double rotAngle      = 0.0;
     double fromPhi       = 0.0;
     double fromCurv      = 0.0;
@@ -932,6 +957,8 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         double dx = toXYZ[0] - fromXYZ[0];
         double dy = toXYZ[1] - fromXYZ[1];
         double dz = toXYZ[2] - fromXYZ[2];
+        xyFirst[0] = crgData->channelX.info.first;
+        xyFirst[1] = crgData->channelY.info.first;
 
         /* --- first rotate --- */
         /* phi on center line */
@@ -940,6 +967,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
+        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -957,32 +985,11 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
+        crgDataOffsetChannelZ( crgData, dz );
 
-        if ( crgData->channelRefZ.info.valid )
-        {
-            for ( i = 0; i < crgData->channelRefZ.info.size; i++ )
-                crgData->channelRefZ.data[i] += dz;
-
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else if ( crgData->admin.defMask & dCrgDataDefZStart )
-        {
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else
-        {
-            for ( i = 0; i < crgData->channelV.info.size; i++ )
-            {
-                crgData->channelZ[i].info.mean   += dz;
-                crgData->channelZ[i].info.first  += dz;
-                crgData->channelZ[i].info.last   += dz;
-                crgData->channelZ[i].info.offset -= dz;
-            }
-        }
+        crgData->channelX.info.offset    -= crgData->channelX.info.first - xyFirst[0];
+        crgData->channelY.info.offset    -= crgData->channelY.info.first - xyFirst[1];
+        crgData->channelRefZ.info.offset -= dz;
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -928,6 +928,9 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
     if ( applyXform )
     {
         size_t i;
+        double dx = toXYZ[0] - fromXYZ[0];
+        double dy = toXYZ[1] - fromXYZ[1];
+        double dz = toXYZ[2] - fromXYZ[2];
 
         /* --- first rotate --- */
         /* phi on center line */
@@ -936,6 +939,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
+        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -945,35 +949,41 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
 
         /* x,y data of center line */
         rotatePoint( &( crgData->channelX.info.first ), &( crgData->channelY.info.first ), rotCenter[0], rotCenter[1], rotAngle );
-        rotatePoint( &( crgData->channelX.info.last ),  &( crgData->channelY.info.last ),  rotCenter [0], rotCenter [1], rotAngle );
+        rotatePoint( &( crgData->channelX.info.last ),  &( crgData->channelY.info.last ),  rotCenter[0], rotCenter[1], rotAngle );
 
         for ( i = 0; i < crgData->channelX.info.size; i++ )
-            rotatePoint( &( crgData->channelX.data[i] ), &( crgData->channelY.data[i] ), rotCenter [0], rotCenter [1], rotAngle );
+            rotatePoint( &( crgData->channelX.data[i] ), &( crgData->channelY.data[i] ), rotCenter[0], rotCenter[1], rotAngle );
 
         /* --- translation --- */
-        crgDataOffsetChannel( &( crgData->channelX ), toXYZ[0] - fromXYZ[0] );
-        crgDataOffsetChannel( &( crgData->channelY ), toXYZ[1] - fromXYZ[1] );
+        crgDataOffsetChannel( &( crgData->channelX ), dx );
+        crgDataOffsetChannel( &( crgData->channelY ), dy );
+
+        crgData->channelX.info.offset -= dx;
+        crgData->channelY.info.offset -= dy;
 
         if ( crgData->channelRefZ.info.valid )
         {
             for ( i = 0; i < crgData->channelRefZ.info.size; i++ )
-                crgData->channelRefZ.data[i] += toXYZ[2] - fromXYZ[2];
+                crgData->channelRefZ.data[i] += dz;
 
-            crgData->channelRefZ.info.first += toXYZ[2] - fromXYZ[2];
-            crgData->channelRefZ.info.last  += toXYZ[2] - fromXYZ[2];
+            crgData->channelRefZ.info.first  += dz;
+            crgData->channelRefZ.info.last   += dz;
+            crgData->channelRefZ.info.offset -= dz;
         }
         else if ( crgData->admin.defMask & dCrgDataDefZStart )
         {
-            crgData->channelRefZ.info.first += toXYZ[2] - fromXYZ[2];
-            crgData->channelRefZ.info.last  += toXYZ[2] - fromXYZ[2];
+            crgData->channelRefZ.info.first  += dz;
+            crgData->channelRefZ.info.last   += dz;
+            crgData->channelRefZ.info.offset -= dz;
         }
         else
         {
             for ( i = 0; i < crgData->channelV.info.size; i++ )
             {
-                crgData->channelZ[i].info.mean  += toXYZ[2] - fromXYZ[2];
-                crgData->channelZ[i].info.first += toXYZ[2] - fromXYZ[2];
-                crgData->channelZ[i].info.last  += toXYZ[2] - fromXYZ[2];
+                crgData->channelZ[i].info.mean   += dz;
+                crgData->channelZ[i].info.first  += dz;
+                crgData->channelZ[i].info.last   += dz;
+                crgData->channelZ[i].info.offset -= dz;
             }
         }
     }


### PR DESCRIPTION
Additive inverse of translation and rotation by modifiers should be applied to channel offsets to retain the global position.
This is also necessary to get closer to parity with the Matlab API crg_mods function.

RESOLVES: #130 