### PR TITLE
c-api: bugfix refline forward integration

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -2201,6 +2201,8 @@ calcRefLine( CrgDataStruct* crgData )
         crgMsgPrint( dCrgMsgLevelDebug, "calcRefLine: using simplified (forward) algorithm.\n" );
 
         /* --- integrate phi -> (x,y) from start to end by simple Euler steps, using simple forward integration --- */
+        crgData->channelX.data[0] = crgData->channelX.info.first;
+        crgData->channelY.data[0] = crgData->channelY.info.first;
         for ( i = 0; i < crgData->channelPhi.info.size-1; i++ )
         {
             crgData->channelX.data[i+1] = crgData->channelX.data[i] + crgData->channelU.info.inc * cos( crgData->channelPhi.data[i+1] );


### PR DESCRIPTION
When the crg refline only consist of start and heading but no end, then the end is found by forward integration from the start. But the start was never set before this fix.