### PR TITLE
c-api: always clear include filename

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -3253,18 +3253,11 @@ crgLoaderInit( void )
 static int
 decodeIncludeFile( CrgDataStruct* crgData, const char* buffer, int code )
 {
-    static char filename[1024];
+    static char filename[1024] = { 0 }; 
     static char envVar[256];
-    static int firstTime = 1;
     int result;
 
     /* --- initialize the structures? --- */
-    if ( firstTime )
-    {
-        firstTime = 0;
-        memset( filename, 0, 1024 * sizeof( char ) );
-    }
-
     switch ( code )
     {
         case dOpcodeIncludeItem:
@@ -3388,6 +3381,9 @@ decodeIncludeFile( CrgDataStruct* crgData, const char* buffer, int code )
 
                 mFileLevel--;
 
+                /* reset the filename for successive read operations */
+                memset( filename, 0, sizeof( filename ) );
+
                 if ( !result )
                     return 0;
 
@@ -3396,9 +3392,6 @@ decodeIncludeFile( CrgDataStruct* crgData, const char* buffer, int code )
 
                 crgMsgPrint( dCrgMsgLevelNotice, "--------------------------------------\n" );
                 crgMsgPrint( dCrgMsgLevelNotice, "decodeIncludeFile: continuing with previous file\n" );
-
-                /* reset the filename for successive read operations */
-                memset( filename, 0, sizeof( filename ) );
 
                 return 1;
 


### PR DESCRIPTION
Since the static filename was only cleared on
a successful load of the included file, this could permanently break 
the include feature until program restart.
Also, static arrays are always initialized as zero once, but it is done
explicitly again, to express intent.

Resolves: #129 