### PR TITLE
C-API: Add set/get origin, xyz2enh and enh2xyz functions

### DIFF
--- a/c-api/baselib/CMakeLists.txt
+++ b/c-api/baselib/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 # Source files
 set(OPENCRG_SOURCES
     src/crgContactPoint.c
+    src/crgEvalenh.c
     src/crgEvalpk.c
     src/crgEvaluv2xy.c
     src/crgEvalxy2uv.c

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -565,6 +565,59 @@ extern "C"
     */
     extern int crgEvalxy2pk( int cpId, double x, double y, double* phi, double* curv );
 
+/* ====== METHODS in crgEvalenh.c ====== */
+    /**
+    * convert a given local (x,y,z) position into the corresponding global (e,n,h) position
+    * @param cpId  id of the contact point that is used for the query
+    * @param x     x coordinate
+    * @param y     y coordinate
+    * @param z     z coordinate
+    * @param e     e coordinate
+    * @param n     n coordinate
+    * @param h     h coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgEvalxyz2enh(int cpId, double x, double y, double z, double* e, double* n, double* h);
+
+    /**
+    * convert a given local (x,y,z) position into the corresponding global (e,n,h) position
+    * @param dataSetId  id of the crg dataset that is used for the query
+    * @param x     x coordinate
+    * @param y     y coordinate
+    * @param z     z coordinate
+    * @param e     e coordinate
+    * @param n     n coordinate
+    * @param h     h coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataSetEvalxyz2enh(int dataSetId, double x, double y, double z, double* e, double* n, double* h);
+
+    /**
+    * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
+    * @param cpId  id of the contact point that is used for the query
+    * @param e     e coordinate
+    * @param n     n coordinate
+    * @param h     h coordinate
+    * @param x     x coordinate
+    * @param y     y coordinate
+    * @param z     z coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgEvalenh2xyz(int cpId, double e, double n, double h, double* x, double* y, double* z);
+
+    /**
+    * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
+    * @param dataSetId  id of the crg dataset that is used for the query
+    * @param e     e coordinate
+    * @param n     n coordinate
+    * @param h     h coordinate
+    * @param x     x coordinate
+    * @param y     y coordinate
+    * @param z     z coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataSetEvalenh2xyz(int dataSetId, double e, double n, double h, double* x, double* y, double* z);
+
 /* ====== METHODS in crgPortability.c ====== */
     /**
     * print a message with a defined criticality level

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -580,19 +580,6 @@ extern "C"
     extern int crgEvalxyz2enh( int cpId, double x, double y, double z, double* e, double* n, double* h );
 
     /**
-    * convert a given local (x,y,z) position into the corresponding global (e,n,h) position
-    * @param dataSetId  id of the crg dataset that is used for the query
-    * @param x     x coordinate
-    * @param y     y coordinate
-    * @param z     z coordinate
-    * @param e     e coordinate
-    * @param n     n coordinate
-    * @param h     h coordinate
-    * @return 1 if successful, otherwise 0
-    */
-    extern int crgDataSetEvalxyz2enh( int dataSetId, double x, double y, double z, double* e, double* n, double* h );
-
-    /**
     * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
     * @param cpId  id of the contact point that is used for the query
     * @param e     e coordinate
@@ -604,19 +591,6 @@ extern "C"
     * @return 1 if successful, otherwise 0
     */
     extern int crgEvalenh2xyz( int cpId, double e, double n, double h, double* x, double* y, double* z );
-
-    /**
-    * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
-    * @param dataSetId  id of the crg dataset that is used for the query
-    * @param e     e coordinate
-    * @param n     n coordinate
-    * @param h     h coordinate
-    * @param x     x coordinate
-    * @param y     y coordinate
-    * @param z     z coordinate
-    * @return 1 if successful, otherwise 0
-    */
-    extern int crgDataSetEvalenh2xyz( int dataSetId, double e, double n, double h, double* x, double* y, double* z );
 
 /* ====== METHODS in crgPortability.c ====== */
     /**

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -577,7 +577,7 @@ extern "C"
     * @param h     h coordinate
     * @return 1 if successful, otherwise 0
     */
-    extern int crgEvalxyz2enh(int cpId, double x, double y, double z, double* e, double* n, double* h);
+    extern int crgEvalxyz2enh( int cpId, double x, double y, double z, double* e, double* n, double* h );
 
     /**
     * convert a given local (x,y,z) position into the corresponding global (e,n,h) position
@@ -590,7 +590,7 @@ extern "C"
     * @param h     h coordinate
     * @return 1 if successful, otherwise 0
     */
-    extern int crgDataSetEvalxyz2enh(int dataSetId, double x, double y, double z, double* e, double* n, double* h);
+    extern int crgDataSetEvalxyz2enh( int dataSetId, double x, double y, double z, double* e, double* n, double* h );
 
     /**
     * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
@@ -603,7 +603,7 @@ extern "C"
     * @param z     z coordinate
     * @return 1 if successful, otherwise 0
     */
-    extern int crgEvalenh2xyz(int cpId, double e, double n, double h, double* x, double* y, double* z);
+    extern int crgEvalenh2xyz( int cpId, double e, double n, double h, double* x, double* y, double* z );
 
     /**
     * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
@@ -616,7 +616,7 @@ extern "C"
     * @param z     z coordinate
     * @return 1 if successful, otherwise 0
     */
-    extern int crgDataSetEvalenh2xyz(int dataSetId, double e, double n, double h, double* x, double* y, double* z);
+    extern int crgDataSetEvalenh2xyz( int dataSetId, double e, double n, double h, double* x, double* y, double* z );
 
 /* ====== METHODS in crgPortability.c ====== */
     /**

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -301,15 +301,16 @@ extern "C"
 
     /**
     * set the global offset values for a data set;
-    * the local coordinates are changed accordingly, os that no shift
+    * the local coordinates are changed accordingly, so that no shift
     * of evaluated global coordinates will occur
     * @param  dataSetId    identifier of the applicable dataset
     * @param  xoff         new x offset
     * @param  yoff         new y offset
     * @param  zoff         new z offset
+    * @param  poff         new p angle offset
     * @return 1 if successful, otherwise 0
     */
-    extern int crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff);
+    extern int crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff);
 
     /**
     * release all data held by the crg library

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -146,11 +146,12 @@
 #endif 
 /* ====== TYPE DEFINITIONS ====== */
 
-/* ====== METHODS in crgMgr.c ====== */
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+/* ====== METHODS in crgMgr.c ====== */
     /**
     * destroy the data of the given data set
     * @param dataSetId    identifier of the applicable dataset
@@ -297,6 +298,18 @@ extern "C"
     * @param  dataSetId    identifier of the applicable dataset
     */
     extern void crgDataSetOptionSetDefault( int dataSetId );
+
+    /**
+    * set the global offset values for a data set;
+    * the local coordinates are changed accordingly, os that no shift
+    * of evaluated global coordinates will occur
+    * @param  dataSetId    identifier of the applicable dataset
+    * @param  xoff         new x offset
+    * @param  yoff         new y offset
+    * @param  zoff         new z offset
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff);
 
     /**
     * release all data held by the crg library

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -313,6 +313,17 @@ extern "C"
     extern int crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff);
 
     /**
+    * get the global offset values for a data set;
+    * @param  dataSetId    identifier of the applicable dataset
+    * @param  xoff         x offset return value
+    * @param  yoff         y offset return value
+    * @param  zoff         z offset return value
+    * @param  poff         p angle offset return value
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataSetGetGlobalOrigin(int dataSetId, double* xoff, double* yoff, double* zoff, double* poff);
+
+    /**
     * release all data held by the crg library
     */
     extern void crgMemRelease( void );

--- a/c-api/baselib/inc/crgBaseLib.h
+++ b/c-api/baselib/inc/crgBaseLib.h
@@ -310,7 +310,7 @@ extern "C"
     * @param  poff         new p angle offset
     * @return 1 if successful, otherwise 0
     */
-    extern int crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff);
+    extern int crgDataSetSetGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff);
 
     /**
     * get the global offset values for a data set;

--- a/c-api/baselib/inc/crgBaseLibPrivate.h
+++ b/c-api/baselib/inc/crgBaseLibPrivate.h
@@ -694,6 +694,33 @@ extern int mCrgBigEndian;             /* endian-ness of machine */
     */
     extern int crgDataEvaluv2pk( const CrgDataStruct *crgData, const CrgOptionsStruct* optionList, double u, double v, double* phi, double* curv );
 
+/* ====== METHODS in crgEvalenh.c ====== */
+    /**
+    * convert a given local (x,y,z) position into the corresponding global (e,n,h) position
+    * @param crgData  pointer to data set which holds the data
+    * @param x        x coordinate
+    * @param y        y coordinate
+    * @param z        z coordinate
+    * @param e        e coordinate
+    * @param n        n coordinate
+    * @param h        h coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataEvalxyz2enh( const CrgDataStruct* crgData, double x, double y, double z, double* e, double* n, double* h );
+
+    /**
+    * convert a given global (e,n,h) position into the corresponding local (x,y,z) position
+    * @param crgData  pointer to data set which holds the data
+    * @param e        e coordinate
+    * @param n        n coordinate
+    * @param h        h coordinate
+    * @param x        x coordinate
+    * @param y        y coordinate
+    * @param z        z coordinate
+    * @return 1 if successful, otherwise 0
+    */
+    extern int crgDataEvalenh2xyz( const CrgDataStruct* crgData, double e, double n, double h, double* x, double* y, double* z );
+
 /* ====== METHODS in crgPortability.c ====== */
     /**
     * set the maximum level of messages that will be handled,

--- a/c-api/baselib/inc/crgBaseLibPrivate.h
+++ b/c-api/baselib/inc/crgBaseLibPrivate.h
@@ -115,6 +115,8 @@ typedef struct
     double  phiFirstCos;  /* cosine of first phi value                        [-] */
     double  phiLastSin;   /* sine   of last phi value                         [-] */
     double  phiLastCos;   /* cosine of last phi value                         [-] */
+    double  phiOffSin;    /* sine   of phi offset value                       [-] */
+    double  phiOffCos;    /* cosine of phi offset value                       [-] */
 } CrgUtilityStruct;
 
 /**

--- a/c-api/baselib/makefile
+++ b/c-api/baselib/makefile
@@ -50,6 +50,7 @@ SOURCES = \
 	crgEvaluv2xy.c \
 	crgEvalz.c \
 	crgEvalpk.c \
+	crgEvalenh.c \
         crgLoader.c \
         crgOptionMgmt.c \
         crgPortability.c

--- a/c-api/baselib/src/crgEvalenh.c
+++ b/c-api/baselib/src/crgEvalenh.c
@@ -67,8 +67,8 @@ crgDataEvalxyz2enh( const CrgDataStruct *crgData, double x, double y, double z, 
     double xbeg = crgData->channelX.info.first;
     double ybeg = crgData->channelY.info.first;
 
-    double ps = sin(crgData->channelPhi.info.offset);
-    double pc = cos(crgData->channelPhi.info.offset);
+    double ps = crgData->util.phiOffSin;
+    double pc = crgData->util.phiOffCos;
 
     /* --- rotate around(xbeg, ybeg) --- */
     double dx = x - xbeg;
@@ -120,8 +120,8 @@ crgDataEvalenh2xyz( const CrgDataStruct* crgData, double e, double n, double h, 
     double xbeg = crgData->channelX.info.first;
     double ybeg = crgData->channelY.info.first;
 
-    double ps = sin(crgData->channelPhi.info.offset);
-    double pc = cos(crgData->channelPhi.info.offset);
+    double ps = crgData->util.phiOffSin;
+    double pc = crgData->util.phiOffCos;
 
     /* --- translate --- */
     *x = e - crgData->channelX.info.offset;

--- a/c-api/baselib/src/crgEvalenh.c
+++ b/c-api/baselib/src/crgEvalenh.c
@@ -44,20 +44,6 @@ crgEvalxyz2enh( int cpId, double x, double y, double z, double* e, double* n, do
     return crgDataEvalxyz2enh(cp->crgData, x, y, z, e, n, h);
 }
 
-int 
-crgDataSetEvalxyz2enh( int dataSetId, double x, double y, double z, double* e, double* n, double* h )
-{
-    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
-
-    if (!crgData)
-    {
-        crgMsgPrint(dCrgMsgLevelNotice, "crgDataSetEvalxyz2enh: unknown data set %d\n", dataSetId);
-        return 0;
-    }
-
-    return crgDataEvalxyz2enh(crgData, x, y, z, e, n, h);
-}
-
 int
 crgDataEvalxyz2enh( const CrgDataStruct *crgData, double x, double y, double z, double* e, double* n, double* h )
 {
@@ -95,20 +81,6 @@ crgEvalenh2xyz( int cpId, double e, double n, double h, double* x, double* y, do
         return 0;
 
     return crgDataEvalenh2xyz(cp->crgData, e, n, h, x, y, z);
-}
-
-int
-crgDataSetEvalenh2xyz(int dataSetId, double e, double n, double h, double* x, double* y, double* z )
-{
-    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
-
-    if (!crgData)
-    {
-        crgMsgPrint(dCrgMsgLevelNotice, "crgDataSetEvalenh2xyz: unknown data set %d\n", dataSetId);
-        return 0;
-    }
-
-    return crgDataEvalenh2xyz(crgData, e, n, h, x, y, z);
 }
 
 int

--- a/c-api/baselib/src/crgEvalenh.c
+++ b/c-api/baselib/src/crgEvalenh.c
@@ -1,0 +1,138 @@
+/* ===================================================
+ *  convert a xyz to enh coordinates and vice versa
+ * ---------------------------------------------------
+ *
+ * See the NOTICE file distributed with this work regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * More Information on ASAM OpenCRG can be found here:
+ * https://www.asam.net/standards/detail/opencrg/
+ *
+ */
+/* ====== INCLUSIONS ====== */
+#include "crgBaseLibPrivate.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ====== DEFINITIONS ====== */
+
+/* ====== TYPE DEFINITIONS ====== */
+
+/* ====== LOCAL METHODS ====== */
+
+/* ====== IMPLEMENTATION ====== */
+int
+crgEvalxyz2enh( int cpId, double x, double y, double z, double* e, double* n, double* h)
+{
+    const CrgContactPointStruct* cp;
+
+    if ( !( cp = crgContactPointGetFromId( cpId ) ) )
+        return 0;
+
+    return crgDataEvalxyz2enh(cp->crgData, x, y, z, e, n, h);
+}
+
+int 
+crgDataSetEvalxyz2enh( int dataSetId, double x, double y, double z, double* e, double* n, double* h )
+{
+    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+
+    if (!crgData)
+    {
+        crgMsgPrint(dCrgMsgLevelNotice, "crgDataSetEvalxyz2enh: unknown data set %d\n", dataSetId);
+        return 0;
+    }
+
+    return crgDataEvalxyz2enh(crgData, x, y, z, e, n, h);
+}
+
+int
+crgDataEvalxyz2enh( const CrgDataStruct *crgData, double x, double y, double z, double* e, double* n, double* h )
+{
+    if (!crgData)
+        return 0;
+
+    double xbeg = crgData->channelX.info.first;
+    double ybeg = crgData->channelY.info.first;
+
+    double ps = sin(crgData->channelPhi.info.offset);
+    double pc = cos(crgData->channelPhi.info.offset);
+
+    /* --- rotate around(xbeg, ybeg) --- */
+    double dx = x - xbeg;
+    double dy = y - ybeg;
+
+    *e = xbeg + dx * pc - dy * ps;
+    *n = ybeg + dx * ps + dy * pc;
+    *h = z;
+
+    /* --- translate --- */
+    *e += crgData->channelX.info.offset;
+    *n += crgData->channelY.info.offset;
+    *h += crgData->channelRefZ.info.offset;
+
+    return 1;
+}
+
+int
+crgEvalenh2xyz( int cpId, double e, double n, double h, double* x, double* y, double* z )
+{
+    const CrgContactPointStruct* cp;
+
+    if (!(cp = crgContactPointGetFromId(cpId)))
+        return 0;
+
+    return crgDataEvalenh2xyz(cp->crgData, e, n, h, x, y, z);
+}
+
+int
+crgDataSetEvalenh2xyz(int dataSetId, double e, double n, double h, double* x, double* y, double* z )
+{
+    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+
+    if (!crgData)
+    {
+        crgMsgPrint(dCrgMsgLevelNotice, "crgDataSetEvalenh2xyz: unknown data set %d\n", dataSetId);
+        return 0;
+    }
+
+    return crgDataEvalenh2xyz(crgData, e, n, h, x, y, z);
+}
+
+int
+crgDataEvalenh2xyz( const CrgDataStruct* crgData, double e, double n, double h, double* x, double* y, double* z )
+{
+    if (!crgData)
+        return 0;
+
+    double xbeg = crgData->channelX.info.first;
+    double ybeg = crgData->channelY.info.first;
+
+    double ps = sin(crgData->channelPhi.info.offset);
+    double pc = cos(crgData->channelPhi.info.offset);
+
+    /* --- translate --- */
+    *x = e - crgData->channelX.info.offset;
+    *y = n - crgData->channelY.info.offset;
+    *z = h - crgData->channelRefZ.info.offset;
+
+    /* --- rotate around(xbeg, ybeg) --- */
+    double dx = *x - xbeg;
+    double dy = *y - ybeg;
+    *x = xbeg + dx * pc + dy * ps;
+    *y = ybeg - dx * ps + dy * pc;
+
+    return 1;
+}

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -724,7 +724,7 @@ crgDataSetOptionSetDefault( int dataSetId )
 }
 
 int
-crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zoff, double poff )
+crgDataSetSetGlobalOrigin( int dataSetId, double xoff, double yoff, double zoff, double poff )
 {
     size_t i;
     double dxoff;
@@ -736,7 +736,7 @@ crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zo
 
     if (!crgData)
     {
-        crgMsgPrint( dCrgMsgLevelWarn, "crgDataSetChangeGlobalOrigin: invalid data set id <%d>.\n", dataSetId );
+        crgMsgPrint( dCrgMsgLevelWarn, "crgDataSetSetGlobalOrigin: invalid data set id <%d>.\n", dataSetId );
         return 0;
     }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -769,6 +769,25 @@ crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zof
     return 1;
 }
 
+int
+crgDataSetGetGlobalOrigin(int dataSetId, double* xoff, double* yoff, double* zoff, double* poff)
+{
+    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+
+    if (!crgData)
+    {
+        crgMsgPrint(dCrgMsgLevelWarn, "crgDataSetGetGlobalOrigin: invalid data set id <%d>.\n", dataSetId);
+        return 0;
+    }
+
+    *xoff = crgData->channelX.info.offset;
+    *yoff = crgData->channelY.info.offset;
+    *zoff = crgData->channelRefZ.info.offset;
+    *poff = crgData->channelPhi.info.offset;
+
+    return 1;
+}
+
 void
 crgMemRelease( void )
 {

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -686,6 +686,8 @@ crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
     if (!crgData)
         return;
 
+    crgData->channelRefZ.info.offset -= offset;
+
     if (crgData->channelRefZ.info.valid)
     {
         for (i = 0; i < crgData->channelRefZ.info.size; i++)
@@ -693,23 +695,11 @@ crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
 
         crgData->channelRefZ.info.first  += offset;
         crgData->channelRefZ.info.last   += offset;
-        crgData->channelRefZ.info.offset -= offset;
-    }
-    else if (crgData->admin.defMask & dCrgDataDefZStart)
-    {
-        crgData->channelRefZ.info.first  += offset;
-        crgData->channelRefZ.info.last   += offset;
-        crgData->channelRefZ.info.offset -= offset;
     }
     else
     {
-        for (i = 0; i < crgData->channelV.info.size; i++)
-        {
-            crgData->channelZ[i].info.mean   += offset;
-            crgData->channelZ[i].info.first  += offset;
-            crgData->channelZ[i].info.last   += offset;
-            crgData->channelZ[i].info.offset -= offset;
-        }
+        crgData->channelRefZ.info.first  += offset;
+        crgData->channelRefZ.info.last   += offset;
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -668,6 +668,7 @@ crgDataOffsetChannel( CrgChannelStruct* channel, double offset )
 
     channel->info.first += offset;
     channel->info.last  += offset;
+    channel->info.offset -= offset;
 }
 
 void
@@ -939,7 +940,6 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
-        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -957,9 +957,6 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
-
-        crgData->channelX.info.offset -= dx;
-        crgData->channelY.info.offset -= dy;
 
         if ( crgData->channelRefZ.info.valid )
         {

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -726,6 +726,12 @@ crgDataSetOptionSetDefault( int dataSetId )
 int
 crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zoff, double poff )
 {
+    int i;
+    double dxoff;
+    double dyoff;
+    double dzoff;
+    double dpoff;
+
     CrgDataStruct* crgData = crgDataSetAccess( dataSetId );
 
     if (!crgData)
@@ -734,13 +740,15 @@ crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zo
         return 0;
     }
 
-    /* --- translate by coordinate offset difference --- */
-    crgDataOffsetChannel( &(crgData->channelX), crgData->channelX.info.offset - xoff );
-    crgDataOffsetChannel( &(crgData->channelY), crgData->channelY.info.offset - yoff );
-    crgDataOffsetChannelZ( crgData, crgData->channelRefZ.info.offset - zoff);
+    /* --- calculate offset residuals --- */
+    dxoff = crgData->channelX.info.offset - xoff;
+    dyoff = crgData->channelY.info.offset - yoff;
+    dzoff = crgData->channelRefZ.info.offset - zoff;
+    dpoff = crgData->channelPhi.info.offset - poff;
 
-    /* --- rotate by heading offset difference --- */
-    crgDataOffsetChannel( &(crgData->channelPhi), crgData->channelPhi.info.offset - poff );
+    /* --- rotate by heading offset difference --- */    
+    crgDataOffsetChannel( &(crgData->channelPhi), dpoff);
+    crgData->channelPhi.info.offset -= dpoff;
 
     /* --- compute sine and cosine of direction at either end of reference line --- */
     crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -749,6 +757,21 @@ crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zo
     crgData->util.phiLastCos  = cos( crgData->channelPhi.info.last  );
     crgData->util.phiOffSin   = sin( crgData->channelPhi.info.offset );
     crgData->util.phiOffCos   = cos( crgData->channelPhi.info.offset );
+
+    /* --- rotate around refline start --- */
+    rotatePoint(&(crgData->channelX.info.last), &(crgData->channelY.info.last), crgData->channelX.info.first, crgData->channelY.info.first, dpoff);
+
+    for (i = 0; i < crgData->channelX.info.size; i++)
+        rotatePoint(&(crgData->channelX.data[i]), &(crgData->channelY.data[i]), crgData->channelX.info.first, crgData->channelY.info.first, dpoff);
+
+    /* --- translate by coordinate offset residuals --- */
+    crgDataOffsetChannel( &(crgData->channelX), dxoff);
+    crgDataOffsetChannel( &(crgData->channelY), dyoff);
+    crgDataOffsetChannelZ( crgData, dzoff);
+
+    crgData->channelX.info.offset -= dxoff;
+    crgData->channelY.info.offset -= dyoff;
+    crgData->channelRefZ.info.offset -= dzoff;
 
     return 1;
 }

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -47,6 +47,13 @@ static void crgDataScaleChannel( CrgChannelBaseStruct* channel, double factor, i
 static void crgDataOffsetChannel( CrgChannelStruct* channel, double offset );
 
 /**
+* offset the data of channelZ or channelRefZ depending on availability
+* @param channel    pointer to data set
+* @param offset     offset value
+*/
+static void crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset);
+
+/**
 * apply any transformation specified by modifiers
 * @param crgData    pointer to data set which is to be modified
 */
@@ -668,7 +675,24 @@ crgDataOffsetChannel( CrgChannelStruct* channel, double offset )
 
     channel->info.first += offset;
     channel->info.last  += offset;
-    channel->info.offset -= offset;
+}
+
+static void
+crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
+{
+    size_t i;
+
+    if (!crgData)
+        return;
+
+    crgData->channelRefZ.info.first  += offset;
+    crgData->channelRefZ.info.last   += offset;
+
+    if (crgData->channelRefZ.info.valid)
+    {
+        for (i = 0; i < crgData->channelRefZ.info.size; i++)
+            crgData->channelRefZ.data[i] += offset;
+    }
 }
 
 void
@@ -789,6 +813,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
     double fromXYZ[3]    = { 0.0, 0.0, 0.0 };
     double toXYZ[3]      = { 0.0, 0.0, 0.0 };
     double rotCenter[2]  = { 0.0, 0.0 };
+    double xyFirst[2]    = { 0.0, 0.0 };
     double rotAngle      = 0.0;
     double fromPhi       = 0.0;
     double fromCurv      = 0.0;
@@ -932,6 +957,8 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         double dx = toXYZ[0] - fromXYZ[0];
         double dy = toXYZ[1] - fromXYZ[1];
         double dz = toXYZ[2] - fromXYZ[2];
+        xyFirst[0] = crgData->channelX.info.first;
+        xyFirst[1] = crgData->channelY.info.first;
 
         /* --- first rotate --- */
         /* phi on center line */
@@ -940,6 +967,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
+        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -957,32 +985,11 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
+        crgDataOffsetChannelZ( crgData, dz );
 
-        if ( crgData->channelRefZ.info.valid )
-        {
-            for ( i = 0; i < crgData->channelRefZ.info.size; i++ )
-                crgData->channelRefZ.data[i] += dz;
-
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else if ( crgData->admin.defMask & dCrgDataDefZStart )
-        {
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else
-        {
-            for ( i = 0; i < crgData->channelV.info.size; i++ )
-            {
-                crgData->channelZ[i].info.mean   += dz;
-                crgData->channelZ[i].info.first  += dz;
-                crgData->channelZ[i].info.last   += dz;
-                crgData->channelZ[i].info.offset -= dz;
-            }
-        }
+        crgData->channelX.info.offset    -= crgData->channelX.info.first - xyFirst[0];
+        crgData->channelY.info.offset    -= crgData->channelY.info.first - xyFirst[1];
+        crgData->channelRefZ.info.offset -= dz;
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -742,7 +742,7 @@ crgDataSetOptionSetDefault( int dataSetId )
 }
 
 int
-crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff)
+crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff)
 {
     CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
 
@@ -752,10 +752,19 @@ crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zof
         return 0;
     }
 
-    /* --- translate by offset difference --- */
+    /* --- translate by coordinate offset difference --- */
     crgDataOffsetChannel(&(crgData->channelX), crgData->channelX.info.offset - xoff);
     crgDataOffsetChannel(&(crgData->channelY), crgData->channelY.info.offset - yoff);
     crgDataOffsetChannelZ(crgData, crgData->channelRefZ.info.offset - zoff);
+
+    /* --- rotate by heading offset difference --- */
+    crgDataOffsetChannel(&(crgData->channelPhi), crgData->channelPhi.info.offset - poff);
+
+    /* --- compute sine and cosine of direction at either end of reference line --- */
+    crgData->util.phiFirstSin = sin(crgData->channelPhi.info.first);
+    crgData->util.phiFirstCos = cos(crgData->channelPhi.info.first);
+    crgData->util.phiLastSin  = sin(crgData->channelPhi.info.last);
+    crgData->util.phiLastCos  = cos(crgData->channelPhi.info.last);
 
     return 1;
 }

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -726,7 +726,7 @@ crgDataSetOptionSetDefault( int dataSetId )
 int
 crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zoff, double poff )
 {
-    int i;
+    size_t i;
     double dxoff;
     double dyoff;
     double dzoff;

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -732,41 +732,43 @@ crgDataSetOptionSetDefault( int dataSetId )
 }
 
 int
-crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff, double poff)
+crgDataSetChangeGlobalOrigin( int dataSetId, double xoff, double yoff, double zoff, double poff )
 {
-    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+    CrgDataStruct* crgData = crgDataSetAccess( dataSetId );
 
     if (!crgData)
     {
-        crgMsgPrint(dCrgMsgLevelWarn, "crgDataSetChangeGlobalOrigin: invalid data set id <%d>.\n", dataSetId);
+        crgMsgPrint( dCrgMsgLevelWarn, "crgDataSetChangeGlobalOrigin: invalid data set id <%d>.\n", dataSetId );
         return 0;
     }
 
     /* --- translate by coordinate offset difference --- */
-    crgDataOffsetChannel(&(crgData->channelX), crgData->channelX.info.offset - xoff);
-    crgDataOffsetChannel(&(crgData->channelY), crgData->channelY.info.offset - yoff);
-    crgDataOffsetChannelZ(crgData, crgData->channelRefZ.info.offset - zoff);
+    crgDataOffsetChannel( &(crgData->channelX), crgData->channelX.info.offset - xoff );
+    crgDataOffsetChannel( &(crgData->channelY), crgData->channelY.info.offset - yoff );
+    crgDataOffsetChannelZ( crgData, crgData->channelRefZ.info.offset - zoff);
 
     /* --- rotate by heading offset difference --- */
-    crgDataOffsetChannel(&(crgData->channelPhi), crgData->channelPhi.info.offset - poff);
+    crgDataOffsetChannel( &(crgData->channelPhi), crgData->channelPhi.info.offset - poff );
 
     /* --- compute sine and cosine of direction at either end of reference line --- */
-    crgData->util.phiFirstSin = sin(crgData->channelPhi.info.first);
-    crgData->util.phiFirstCos = cos(crgData->channelPhi.info.first);
-    crgData->util.phiLastSin  = sin(crgData->channelPhi.info.last);
-    crgData->util.phiLastCos  = cos(crgData->channelPhi.info.last);
+    crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
+    crgData->util.phiFirstCos = cos( crgData->channelPhi.info.first );
+    crgData->util.phiLastSin  = sin( crgData->channelPhi.info.last  );
+    crgData->util.phiLastCos  = cos( crgData->channelPhi.info.last  );
+    crgData->util.phiOffSin   = sin( crgData->channelPhi.info.offset );
+    crgData->util.phiOffCos   = cos( crgData->channelPhi.info.offset );
 
     return 1;
 }
 
 int
-crgDataSetGetGlobalOrigin(int dataSetId, double* xoff, double* yoff, double* zoff, double* poff)
+crgDataSetGetGlobalOrigin( int dataSetId, double* xoff, double* yoff, double* zoff, double* poff )
 {
-    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+    CrgDataStruct* crgData = crgDataSetAccess( dataSetId );
 
     if (!crgData)
     {
-        crgMsgPrint(dCrgMsgLevelWarn, "crgDataSetGetGlobalOrigin: invalid data set id <%d>.\n", dataSetId);
+        crgMsgPrint(dCrgMsgLevelWarn, "crgDataSetGetGlobalOrigin: invalid data set id <%d>.\n", dataSetId );
         return 0;
     }
 
@@ -1025,6 +1027,8 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         crgData->util.phiFirstCos = cos( crgData->channelPhi.info.first );
         crgData->util.phiLastSin  = sin( crgData->channelPhi.info.last  );
         crgData->util.phiLastCos  = cos( crgData->channelPhi.info.last  );
+        crgData->util.phiOffSin   = sin( crgData->channelPhi.info.offset );
+        crgData->util.phiOffCos   = cos( crgData->channelPhi.info.offset );
 
         /* x,y data of center line */
         rotatePoint( &( crgData->channelX.info.first ), &( crgData->channelY.info.first ), rotCenter[0], rotCenter[1], rotAngle );
@@ -1036,7 +1040,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
-        crgDataOffsetChannelZ(crgData, dz);
+        crgDataOffsetChannelZ( crgData, dz );
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -47,6 +47,13 @@ static void crgDataScaleChannel( CrgChannelBaseStruct* channel, double factor, i
 static void crgDataOffsetChannel( CrgChannelStruct* channel, double offset );
 
 /**
+* offset the data of channelZ or channelRefZ depending on availability
+* @param channel    pointer to data set
+* @param offset     offset value
+*/
+static void crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset);
+
+/**
 * apply any transformation specified by modifiers
 * @param crgData    pointer to data set which is to be modified
 */
@@ -671,6 +678,41 @@ crgDataOffsetChannel( CrgChannelStruct* channel, double offset )
     channel->info.offset -= offset;
 }
 
+static void
+crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
+{
+    size_t i;
+
+    if (!crgData)
+        return;
+
+    if (crgData->channelRefZ.info.valid)
+    {
+        for (i = 0; i < crgData->channelRefZ.info.size; i++)
+            crgData->channelRefZ.data[i] += offset;
+
+        crgData->channelRefZ.info.first  += offset;
+        crgData->channelRefZ.info.last   += offset;
+        crgData->channelRefZ.info.offset -= offset;
+    }
+    else if (crgData->admin.defMask & dCrgDataDefZStart)
+    {
+        crgData->channelRefZ.info.first  += offset;
+        crgData->channelRefZ.info.last   += offset;
+        crgData->channelRefZ.info.offset -= offset;
+    }
+    else
+    {
+        for (i = 0; i < crgData->channelV.info.size; i++)
+        {
+            crgData->channelZ[i].info.mean   += offset;
+            crgData->channelZ[i].info.first  += offset;
+            crgData->channelZ[i].info.last   += offset;
+            crgData->channelZ[i].info.offset -= offset;
+        }
+    }
+}
+
 void
 crgDataSetModifierSetDefault( int dataSetId )
 {
@@ -697,6 +739,25 @@ crgDataSetOptionSetDefault( int dataSetId )
     }
 
     crgOptionSetDefaultOptions( &( crgData->options ) );
+}
+
+int
+crgDataSetChangeGlobalOrigin(int dataSetId, double xoff, double yoff, double zoff)
+{
+    CrgDataStruct* crgData = crgDataSetAccess(dataSetId);
+
+    if (!crgData)
+    {
+        crgMsgPrint(dCrgMsgLevelWarn, "crgDataSetChangeGlobalOrigin: invalid data set id <%d>.\n", dataSetId);
+        return 0;
+    }
+
+    /* --- translate by offset difference --- */
+    crgDataOffsetChannel(&(crgData->channelX), crgData->channelX.info.offset - xoff);
+    crgDataOffsetChannel(&(crgData->channelY), crgData->channelY.info.offset - yoff);
+    crgDataOffsetChannelZ(crgData, crgData->channelRefZ.info.offset - zoff);
+
+    return 1;
 }
 
 void
@@ -957,32 +1018,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
         /* --- translation --- */
         crgDataOffsetChannel( &( crgData->channelX ), dx );
         crgDataOffsetChannel( &( crgData->channelY ), dy );
-
-        if ( crgData->channelRefZ.info.valid )
-        {
-            for ( i = 0; i < crgData->channelRefZ.info.size; i++ )
-                crgData->channelRefZ.data[i] += dz;
-
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else if ( crgData->admin.defMask & dCrgDataDefZStart )
-        {
-            crgData->channelRefZ.info.first  += dz;
-            crgData->channelRefZ.info.last   += dz;
-            crgData->channelRefZ.info.offset -= dz;
-        }
-        else
-        {
-            for ( i = 0; i < crgData->channelV.info.size; i++ )
-            {
-                crgData->channelZ[i].info.mean   += dz;
-                crgData->channelZ[i].info.first  += dz;
-                crgData->channelZ[i].info.last   += dz;
-                crgData->channelZ[i].info.offset -= dz;
-            }
-        }
+        crgDataOffsetChannelZ(crgData, dz);
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -687,19 +687,13 @@ crgDataOffsetChannelZ(CrgDataStruct* crgData, double offset)
         return;
 
     crgData->channelRefZ.info.offset -= offset;
+    crgData->channelRefZ.info.first  += offset;
+    crgData->channelRefZ.info.last   += offset;
 
     if (crgData->channelRefZ.info.valid)
     {
         for (i = 0; i < crgData->channelRefZ.info.size; i++)
             crgData->channelRefZ.data[i] += offset;
-
-        crgData->channelRefZ.info.first  += offset;
-        crgData->channelRefZ.info.last   += offset;
-    }
-    else
-    {
-        crgData->channelRefZ.info.first  += offset;
-        crgData->channelRefZ.info.last   += offset;
     }
 }
 

--- a/c-api/baselib/src/crgMgr.c
+++ b/c-api/baselib/src/crgMgr.c
@@ -928,6 +928,9 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
     if ( applyXform )
     {
         size_t i;
+        double dx = toXYZ[0] - fromXYZ[0];
+        double dy = toXYZ[1] - fromXYZ[1];
+        double dz = toXYZ[2] - fromXYZ[2];
 
         /* --- first rotate --- */
         /* phi on center line */
@@ -936,6 +939,7 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
                 rotAngle * 180 / 3.14159265, rotCenter[0], rotCenter[1], fromPhi * 180 / 3.14159265 );
 
         crgDataOffsetChannel( &( crgData->channelPhi ), rotAngle );
+        crgData->channelPhi.info.offset -= rotAngle;
 
         /* --- compute sine and cosine of direction at either end of reference line */
         crgData->util.phiFirstSin = sin( crgData->channelPhi.info.first );
@@ -945,35 +949,41 @@ crgDataApplyTransformations( CrgDataStruct *crgData )
 
         /* x,y data of center line */
         rotatePoint( &( crgData->channelX.info.first ), &( crgData->channelY.info.first ), rotCenter[0], rotCenter[1], rotAngle );
-        rotatePoint( &( crgData->channelX.info.last ),  &( crgData->channelY.info.last ),  rotCenter [0], rotCenter [1], rotAngle );
+        rotatePoint( &( crgData->channelX.info.last ),  &( crgData->channelY.info.last ),  rotCenter[0], rotCenter[1], rotAngle );
 
         for ( i = 0; i < crgData->channelX.info.size; i++ )
-            rotatePoint( &( crgData->channelX.data[i] ), &( crgData->channelY.data[i] ), rotCenter [0], rotCenter [1], rotAngle );
+            rotatePoint( &( crgData->channelX.data[i] ), &( crgData->channelY.data[i] ), rotCenter[0], rotCenter[1], rotAngle );
 
         /* --- translation --- */
-        crgDataOffsetChannel( &( crgData->channelX ), toXYZ[0] - fromXYZ[0] );
-        crgDataOffsetChannel( &( crgData->channelY ), toXYZ[1] - fromXYZ[1] );
+        crgDataOffsetChannel( &( crgData->channelX ), dx );
+        crgDataOffsetChannel( &( crgData->channelY ), dy );
+
+        crgData->channelX.info.offset -= dx;
+        crgData->channelY.info.offset -= dy;
 
         if ( crgData->channelRefZ.info.valid )
         {
             for ( i = 0; i < crgData->channelRefZ.info.size; i++ )
-                crgData->channelRefZ.data[i] += toXYZ[2] - fromXYZ[2];
+                crgData->channelRefZ.data[i] += dz;
 
-            crgData->channelRefZ.info.first += toXYZ[2] - fromXYZ[2];
-            crgData->channelRefZ.info.last  += toXYZ[2] - fromXYZ[2];
+            crgData->channelRefZ.info.first  += dz;
+            crgData->channelRefZ.info.last   += dz;
+            crgData->channelRefZ.info.offset -= dz;
         }
         else if ( crgData->admin.defMask & dCrgDataDefZStart )
         {
-            crgData->channelRefZ.info.first += toXYZ[2] - fromXYZ[2];
-            crgData->channelRefZ.info.last  += toXYZ[2] - fromXYZ[2];
+            crgData->channelRefZ.info.first  += dz;
+            crgData->channelRefZ.info.last   += dz;
+            crgData->channelRefZ.info.offset -= dz;
         }
         else
         {
             for ( i = 0; i < crgData->channelV.info.size; i++ )
             {
-                crgData->channelZ[i].info.mean  += toXYZ[2] - fromXYZ[2];
-                crgData->channelZ[i].info.first += toXYZ[2] - fromXYZ[2];
-                crgData->channelZ[i].info.last  += toXYZ[2] - fromXYZ[2];
+                crgData->channelZ[i].info.mean   += dz;
+                crgData->channelZ[i].info.first  += dz;
+                crgData->channelZ[i].info.last   += dz;
+                crgData->channelZ[i].info.offset -= dz;
             }
         }
     }

--- a/c-api/baselib/src/crgStatistics.c
+++ b/c-api/baselib/src/crgStatistics.c
@@ -258,6 +258,8 @@ void crgCalcUtilityData( CrgDataStruct *crgData )
     crgData->util.phiFirstCos = cos( crgData->channelPhi.info.first );
     crgData->util.phiLastSin  = sin( crgData->channelPhi.info.last  );
     crgData->util.phiLastCos  = cos( crgData->channelPhi.info.last  );
+    crgData->util.phiOffSin   = sin( crgData->channelPhi.info.offset );
+    crgData->util.phiOffCos   = cos( crgData->channelPhi.info.offset );
 
     /* --- reset the "closed" feature --- */
     crgData->util.uIsClosed = 0;


### PR DESCRIPTION
When using multiple CRGs or in conjuction with other external data (e.g. OpenDRIVE maps) it is helpful to be able to evaluate in the same coordinate system.
With this PR the ability to set the global coordinate system origin is added.
Additionally one can transform local crg coordinates to global coordinates analog to existing Matlab API functionality.

RESOLVES: #78