### PR TITLE
c-api: fix wrong default refpoint v mod on check

### DIFF
--- a/c-api/baselib/src/crgLoader.c
+++ b/c-api/baselib/src/crgLoader.c
@@ -2968,8 +2968,8 @@ crgCheckMods( CrgDataStruct* crgData )
         }
         if ( !crgOptionIsSet( &crgData->modifiers, dCrgModRefPointVFrac ) && !crgOptionIsSet( &crgData->modifiers, dCrgModRefPointV ) )
         {
-            crgOptionSetDouble( &crgData->modifiers, dCrgModRefPointVFrac, 0. );
-            crgMsgPrint( dCrgMsgLevelNotice, "crgCheckMods: setting value of modifier \"refpoint_v_fraction\" to 0.0.\n");
+            crgOptionSetDouble( &crgData->modifiers, dCrgModRefPointV, 0. );
+            crgMsgPrint( dCrgMsgLevelNotice, "crgCheckMods: setting value of modifier \"refpoint_v\" to 0.0.\n");
         }
         if( !crgOptionIsSet( &crgData->modifiers, dCrgModRefPointUOffset ) )
             crgOptionSetDouble( &crgData->modifiers, dCrgModRefPointUOffset , 0. );


### PR DESCRIPTION
When calling crgCheck and no v refpoint is set,
then it defaults to setting refpoint_v_fraction to zero. The Matlab API sets refpoint_v to zero which makes more sense and this change makes the C-API consistent with the Matlab-API.

Resolves: #135 