### PR TITLE
c-api: fix eval phi indexing bug (issue #140)

### DIFF
--- a/c-api/baselib/src/crgEvalpk.c
+++ b/c-api/baselib/src/crgEvalpk.c
@@ -152,7 +152,7 @@ crgDataEvaluv2pk( const CrgDataStruct *crgData, const CrgOptionsStruct* optionLi
         /* NOTE: phi will not be interpolated, since the data set consists
                  of a sequence of straight lines with discrete change of
                  direction at the respective end points                   */
-        *phi = crgData->channelPhi.data[indexU];
+        *phi = crgData->channelPhi.data[indexU + 1];
     }
 
     return 1;

--- a/matlab/lib/crg_eval_u2phi.m
+++ b/matlab/lib/crg_eval_u2phi.m
@@ -78,7 +78,7 @@ num1 = size(p, 2); % nu - 1
 %% work on all points
 
 for ip = 1:np
-    iu = floor((pu(ip) - ubeg) / uinc);
+    iu = floor((pu(ip) - ubeg) / uinc) + 1;
     if iu < 1
         phi(ip) = pbeg;
     elseif iu > num1


### PR DESCRIPTION
The valid heading angles phi are stored in the
corresponding array in range [1, Channel Phi size[ but indexing assumed that range starts at index zero.

Resolves: #140 